### PR TITLE
Insert all getters and setters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,735 +1,857 @@
 {
-    "name": "vscode-php-getters-setters",
-    "version": "1.2.3",
-    "lockfileVersion": 1,
-    "requires": true,
-    "dependencies": {
-        "@types/mocha": {
-            "version": "2.2.48",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
-            "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
-            "dev": true
-        },
-        "@types/node": {
-            "version": "7.0.61",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.61.tgz",
-            "integrity": "sha512-X4MNN+Z36OmVPv7n08wxq46/t61/rauW4+xeyxGPueDQ9t7SetHnuEPS0p9n6wU/15HvJLGjzfLTc/RwN7id3A==",
-            "dev": true
-        },
+  "name": "vscode-php-getters-setters-cv",
+  "version": "1.3.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vscode-php-getters-setters-cv",
+      "version": "1.3.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@types/mocha": "^2.2.42",
+        "@types/node": "^7.0.43",
+        "typescript": "^2.6.1",
+        "vscode": "^1.1.37"
+      },
+      "engines": {
+        "vscode": "^1.18.0"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/mocha": {
+      "version": "2.2.48",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
+      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "7.0.61",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.61.tgz",
+      "integrity": "sha512-X4MNN+Z36OmVPv7n08wxq46/t61/rauW4+xeyxGPueDQ9t7SetHnuEPS0p9n6wU/15HvJLGjzfLTc/RwN7id3A==",
+      "dev": true
+    },
+    "node_modules/agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "dev": true,
+      "dependencies": {
+        "es6-promisify": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "node_modules/commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
+    },
+    "node_modules/es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "dependencies": {
+        "es6-promise": "^4.0.3"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "dependencies": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
+      "integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/vscode": {
+      "version": "1.1.37",
+      "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
+      "integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
+      "deprecated": "This package is deprecated in favor of @types/vscode and vscode-test. For more information please read: https://code.visualstudio.com/updates/v1_36#_splitting-vscode-package-into-typesvscode-and-vscodetest",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.2",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "mocha": "^5.2.0",
+        "semver": "^5.4.1",
+        "source-map-support": "^0.5.0",
+        "vscode-test": "^0.4.1"
+      },
+      "bin": {
+        "vscode-install": "bin/install"
+      },
+      "engines": {
+        "node": ">=8.9.3"
+      }
+    },
+    "node_modules/vscode-test": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
+      "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
+      "dev": true,
+      "dependencies": {
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.9.3"
+      }
+    },
+    "node_modules/vscode/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/vscode/node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode/node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/vscode/node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/vscode/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "2.2.48",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
+      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "7.0.61",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.61.tgz",
+      "integrity": "sha512-X4MNN+Z36OmVPv7n08wxq46/t61/rauW4+xeyxGPueDQ9t7SetHnuEPS0p9n6wU/15HvJLGjzfLTc/RwN7id3A==",
+      "dev": true
+    },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "dev": true,
+      "requires": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "typescript": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
+      "integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
+      "dev": true
+    },
+    "vscode": {
+      "version": "1.1.37",
+      "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
+      "integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.2",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "mocha": "^5.2.0",
+        "semver": "^5.4.1",
+        "source-map-support": "^0.5.0",
+        "vscode-test": "^0.4.1"
+      },
+      "dependencies": {
         "agent-base": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-            "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-            "dev": true,
-            "requires": {
-                "es6-promisify": "^5.0.0"
-            }
-        },
-        "ajv": {
-            "version": "6.10.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-            "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-            "dev": true,
-            "requires": {
-                "fast-deep-equal": "^2.0.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            }
-        },
-        "asn1": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-            "dev": true,
-            "requires": {
-                "safer-buffer": "~2.1.0"
-            }
-        },
-        "assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-            "dev": true
-        },
-        "asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-            "dev": true
-        },
-        "aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-            "dev": true
-        },
-        "aws4": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-            "dev": true
-        },
-        "balanced-match": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
-        },
-        "bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-            "dev": true,
-            "requires": {
-                "tweetnacl": "^0.14.3"
-            }
-        },
-        "brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
-            "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "browser-stdout": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-            "dev": true
-        },
-        "buffer-from": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-            "dev": true
-        },
-        "caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-            "dev": true
-        },
-        "combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
-            "requires": {
-                "delayed-stream": "~1.0.0"
-            }
-        },
-        "commander": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-            "dev": true
-        },
-        "concat-map": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
-        },
-        "core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-            "dev": true
-        },
-        "dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "dev": true,
+          "requires": {
+            "debug": "4"
+          }
         },
         "debug": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-            "dev": true,
-            "requires": {
-                "ms": "2.0.0"
-            }
-        },
-        "delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-            "dev": true
-        },
-        "diff": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-            "dev": true
-        },
-        "ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-            "dev": true,
-            "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
-        },
-        "es6-promise": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-            "dev": true
-        },
-        "es6-promisify": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-            "dev": true,
-            "requires": {
-                "es6-promise": "^4.0.3"
-            }
-        },
-        "escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
-        },
-        "extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-            "dev": true
-        },
-        "extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-            "dev": true
-        },
-        "fast-deep-equal": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-            "dev": true
-        },
-        "fast-json-stable-stringify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-            "dev": true
-        },
-        "forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-            "dev": true
-        },
-        "form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-            "dev": true,
-            "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-            }
-        },
-        "fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
-        },
-        "getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
-        },
-        "glob": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-            "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-            "dev": true,
-            "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            }
-        },
-        "growl": {
-            "version": "1.10.5",
-            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-            "dev": true
-        },
-        "har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-            "dev": true
-        },
-        "har-validator": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-            "dev": true,
-            "requires": {
-                "ajv": "^6.5.5",
-                "har-schema": "^2.0.0"
-            }
-        },
-        "has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
-        },
-        "he": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-            "dev": true
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
         },
         "http-proxy-agent": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-            "dev": true,
-            "requires": {
-                "agent-base": "4",
-                "debug": "3.1.0"
-            }
-        },
-        "http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-            }
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+          "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+          "dev": true,
+          "requires": {
+            "@tootallnate/once": "1",
+            "agent-base": "6",
+            "debug": "4"
+          }
         },
         "https-proxy-agent": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-            "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
-            "dev": true,
-            "requires": {
-                "agent-base": "^4.3.0",
-                "debug": "^3.1.0"
-            }
-        },
-        "inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
-            "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
-        },
-        "is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-            "dev": true
-        },
-        "isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-            "dev": true
-        },
-        "jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "dev": true
-        },
-        "json-schema": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-            "dev": true
-        },
-        "json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
-        },
-        "json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-            "dev": true
-        },
-        "jsprim": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-            }
-        },
-        "mime-db": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-            "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-            "dev": true
-        },
-        "mime-types": {
-            "version": "2.1.24",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-            "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-            "dev": true,
-            "requires": {
-                "mime-db": "1.40.0"
-            }
-        },
-        "minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
-            "requires": {
-                "brace-expansion": "^1.1.7"
-            }
-        },
-        "minimist": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-            "dev": true
-        },
-        "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
-            "requires": {
-                "minimist": "0.0.8"
-            }
-        },
-        "mocha": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-            "dev": true,
-            "requires": {
-                "browser-stdout": "1.3.1",
-                "commander": "2.15.1",
-                "debug": "3.1.0",
-                "diff": "3.5.0",
-                "escape-string-regexp": "1.0.5",
-                "glob": "7.1.2",
-                "growl": "1.10.5",
-                "he": "1.1.1",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "supports-color": "5.4.0"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "7.1.2",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                }
-            }
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
         },
         "ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
-        },
-        "oauth-sign": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-            "dev": true
-        },
-        "once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
-            "requires": {
-                "wrappy": "1"
-            }
-        },
-        "path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
-        },
-        "performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-            "dev": true
-        },
-        "psl": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
-            "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==",
-            "dev": true
-        },
-        "punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "dev": true
-        },
-        "qs": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-            "dev": true
-        },
-        "querystringify": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-            "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
-            "dev": true
-        },
-        "request": {
-            "version": "2.88.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-            "dev": true,
-            "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            }
-        },
-        "requires-port": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-            "dev": true
-        },
-        "safe-buffer": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-            "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
-            "dev": true
-        },
-        "safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true
-        },
-        "semver": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-            "dev": true
-        },
-        "source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true
-        },
-        "source-map-support": {
-            "version": "0.5.12",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-            "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
-            "dev": true,
-            "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
-            }
-        },
-        "sshpk": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-            "dev": true,
-            "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            }
-        },
-        "supports-color": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-            "dev": true,
-            "requires": {
-                "has-flag": "^3.0.0"
-            }
-        },
-        "tough-cookie": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-            "dev": true,
-            "requires": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
-            },
-            "dependencies": {
-                "punycode": {
-                    "version": "1.4.1",
-                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                    "dev": true
-                }
-            }
-        },
-        "tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "dev": true
-        },
-        "typescript": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
-            "integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
-            "dev": true
-        },
-        "uri-js": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-            "dev": true,
-            "requires": {
-                "punycode": "^2.1.0"
-            }
-        },
-        "url-parse": {
-            "version": "1.4.7",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-            "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-            "dev": true,
-            "requires": {
-                "querystringify": "^2.1.1",
-                "requires-port": "^1.0.0"
-            }
-        },
-        "uuid": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-            "dev": true
-        },
-        "verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            }
-        },
-        "vscode": {
-            "version": "1.1.35",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.35.tgz",
-            "integrity": "sha512-xPnxzQU40LOS2yPyzWW+WKpTV6qA3z16TcgpZ9O38UWLA157Zz4GxUx5H7Gd07pxzw0GqvusbF4D+5GBgNxvEQ==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.2",
-                "mocha": "^5.2.0",
-                "request": "^2.88.0",
-                "semver": "^5.4.1",
-                "source-map-support": "^0.5.0",
-                "url-parse": "^1.4.4",
-                "vscode-test": "^0.4.1"
-            }
-        },
-        "vscode-test": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
-            "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
-            "dev": true,
-            "requires": {
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.1"
-            }
-        },
-        "wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
+      }
+    },
+    "vscode-test": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
+      "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
+      "dev": true,
+      "requires": {
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,14 @@
         }
       }
     },
+    "keybindings": [
+      {
+        "command": "phpGettersSetters.insertAllGetterAndSetter",
+        "key": "ctrl+alt+g",
+        "mac": "cmd+opt+g",
+        "when": "editorTextFocus"
+      }
+    ],
     "commands": [
       {
         "command": "phpGettersSetters.insertGetter",

--- a/package.json
+++ b/package.json
@@ -85,15 +85,19 @@
     "commands": [
       {
         "command": "phpGettersSetters.insertGetter",
-        "title": "Insert PHP Getter"
+        "title": "Insert pointed PHP Getter"
       },
       {
         "command": "phpGettersSetters.insertSetter",
-        "title": "Insert PHP Setter"
+        "title": "Insert pointed PHP Setter"
       },
       {
         "command": "phpGettersSetters.insertGetterAndSetter",
-        "title": "Insert PHP Getter & Setter"
+        "title": "Insert pointed PHP Getter & Setter"
+      },
+      {
+        "command": "phpGettersSetters.insertAllGetterAndSetter",
+        "title": "Insert all PHP Getter & Setter"
       }
     ],
     "menus": {
@@ -108,6 +112,10 @@
         },
         {
           "command": "phpGettersSetters.insertGetterAndSetter",
+          "when": "editorLangId == php"
+        },
+        {
+          "command": "phpGettersSetters.insertAllGetterAndSetter",
           "when": "editorLangId == php"
         }
       ],
@@ -129,6 +137,12 @@
           "command": "phpGettersSetters.insertGetterAndSetter",
           "alt": "phpGettersSetters.insertGetterAndSetter",
           "group": "0_phpGettersSetters@3"
+        },
+        {
+          "when": "resourceLangId == php",
+          "command": "phpGettersSetters.insertAllGetterAndSetter",
+          "alt": "phpGettersSetters.insertAllGetterAndSetter",
+          "group": "0_phpGettersSetters@4"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -1,149 +1,149 @@
 {
-    "name": "vscode-php-getters-setters-cv",
-    "displayName": "PHP Getters & Setters (CV fork)",
-    "description": "Create PHP getters and setters from class properties",
-    "version": "1.3.0",
-    "publisher": "cvergne",
-    "author": "Roberto Segura <roberto@phproberto.com>",
-    "contributors": [
-        "Christophe VERGNE <dev@christophevergne.fr>"
-    ],
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/cvergne/vscode-php-getters-setters"
-    },
-    "bugs": {
-        "url": "https://github.com/cvergne/vscode-php-getters-setters/issues"
-    },
-    "icon": "images/icon.png",
-    "engines": {
-        "vscode": "^1.18.0"
-    },
-    "categories": [
-        "Other"
-    ],
-    "keywords": [
-        "php",
-        "getter",
-        "getters",
-        "setter",
-        "setters"
-    ],
-    "activationEvents": [
-        "onLanguage:php",
-        "onCommand:phpGettersSetters.insertGetter",
-        "onCommand:phpGettersSetters.insertSetter",
-        "onCommand:phpGettersSetters.insertGetterAndSetter"
-    ],
-    "main": "./out/extension",
-    "contributes": {
-        "configuration": {
-            "type": "object",
-            "title": "PHP getters & setters configuration",
-            "properties": {
-                "phpGettersSetters.redirect": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Redirect to generated functions after creating them?"
-                },
-                "phpGettersSetters.spacesAfterParam": {
-                    "type": "integer",
-                    "default": 2,
-                    "description": "How many spaces should we add after a @param tag?"
-                },
-                "phpGettersSetters.spacesAfterParamVar": {
-                    "type": "integer",
-                    "default": 2,
-                    "description": "How many spaces should we add after a @param variable name?"
-                },
-                "phpGettersSetters.spacesAfterReturn": {
-                    "type": "integer",
-                    "default": 2,
-                    "description": "How many spaces should we add after a @return tag?"
-                },
-                "phpGettersSetters.templatesDir": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null,
-                    "description": "Folder where custom templates are stored"
-                },
-                "phpGettersSetters.getterTemplate": {
-                    "type": "string",
-                    "default": "getter.js",
-                    "description": "File to use as template for getters"
-                },
-                "phpGettersSetters.setterTemplate": {
-                    "type": "string",
-                    "default": "setter.js",
-                    "description": "File to use as template for setters"
-                }
-            }
+  "name": "vscode-php-getters-setters-cv",
+  "displayName": "PHP Getters & Setters (CV fork)",
+  "description": "Create PHP getters and setters from class properties",
+  "version": "1.3.0",
+  "publisher": "cvergne",
+  "author": "Roberto Segura <roberto@phproberto.com>",
+  "contributors": [
+    "Christophe VERGNE <dev@christophevergne.fr>"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cvergne/vscode-php-getters-setters"
+  },
+  "bugs": {
+    "url": "https://github.com/cvergne/vscode-php-getters-setters/issues"
+  },
+  "icon": "images/icon.png",
+  "engines": {
+    "vscode": "^1.18.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "keywords": [
+    "php",
+    "getter",
+    "getters",
+    "setter",
+    "setters"
+  ],
+  "activationEvents": [
+    "onLanguage:php",
+    "onCommand:phpGettersSetters.insertGetter",
+    "onCommand:phpGettersSetters.insertSetter",
+    "onCommand:phpGettersSetters.insertGetterAndSetter"
+  ],
+  "main": "./out/extension",
+  "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "PHP getters & setters configuration",
+      "properties": {
+        "phpGettersSetters.redirect": {
+          "type": "boolean",
+          "default": true,
+          "description": "Redirect to generated functions after creating them?"
         },
-        "commands": [
-            {
-                "command": "phpGettersSetters.insertGetter",
-                "title": "Insert PHP Getter"
-            },
-            {
-                "command": "phpGettersSetters.insertSetter",
-                "title": "Insert PHP Setter"
-            },
-            {
-                "command": "phpGettersSetters.insertGetterAndSetter",
-                "title": "Insert PHP Getter & Setter"
-            }
-        ],
-        "menus": {
-            "commandPalette": [
-                {
-                    "command": "phpGettersSetters.insertGetter",
-                    "when": "editorLangId == php"
-                },
-                {
-                    "command": "phpGettersSetters.insertSetter",
-                    "when": "editorLangId == php"
-                },
-                {
-                    "command": "phpGettersSetters.insertGetterAndSetter",
-                    "when": "editorLangId == php"
-                }
-            ],
-            "editor/context": [
-                {
-                    "when": "resourceLangId == php",
-                    "command": "phpGettersSetters.insertGetter",
-                    "alt": "phpGettersSetters.insertGetter",
-                    "group": "0_phpGettersSetters@1"
-                },
-                {
-                    "when": "resourceLangId == php",
-                    "command": "phpGettersSetters.insertSetter",
-                    "alt": "phpGettersSetters.insertSetter",
-                    "group": "0_phpGettersSetters@2"
-                },
-                {
-                    "when": "resourceLangId == php",
-                    "command": "phpGettersSetters.insertGetterAndSetter",
-                    "alt": "phpGettersSetters.insertGetterAndSetter",
-                    "group": "0_phpGettersSetters@3"
-                }
-            ]
+        "phpGettersSetters.spacesAfterParam": {
+          "type": "integer",
+          "default": 2,
+          "description": "How many spaces should we add after a @param tag?"
+        },
+        "phpGettersSetters.spacesAfterParamVar": {
+          "type": "integer",
+          "default": 2,
+          "description": "How many spaces should we add after a @param variable name?"
+        },
+        "phpGettersSetters.spacesAfterReturn": {
+          "type": "integer",
+          "default": 2,
+          "description": "How many spaces should we add after a @return tag?"
+        },
+        "phpGettersSetters.templatesDir": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Folder where custom templates are stored"
+        },
+        "phpGettersSetters.getterTemplate": {
+          "type": "string",
+          "default": "getter.js",
+          "description": "File to use as template for getters"
+        },
+        "phpGettersSetters.setterTemplate": {
+          "type": "string",
+          "default": "setter.js",
+          "description": "File to use as template for setters"
         }
+      }
     },
-    "scripts": {
-        "vscode:prepublish": "npm run compile",
-        "compile": "tsc -p ./",
-        "watch": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "npm run compile && node ./node_modules/vscode/bin/test"
-    },
-    "devDependencies": {
-        "typescript": "^2.6.1",
-        "vscode": "^1.1.35",
-        "@types/node": "^7.0.43",
-        "@types/mocha": "^2.2.42"
+    "commands": [
+      {
+        "command": "phpGettersSetters.insertGetter",
+        "title": "Insert PHP Getter"
+      },
+      {
+        "command": "phpGettersSetters.insertSetter",
+        "title": "Insert PHP Setter"
+      },
+      {
+        "command": "phpGettersSetters.insertGetterAndSetter",
+        "title": "Insert PHP Getter & Setter"
+      }
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "phpGettersSetters.insertGetter",
+          "when": "editorLangId == php"
+        },
+        {
+          "command": "phpGettersSetters.insertSetter",
+          "when": "editorLangId == php"
+        },
+        {
+          "command": "phpGettersSetters.insertGetterAndSetter",
+          "when": "editorLangId == php"
+        }
+      ],
+      "editor/context": [
+        {
+          "when": "resourceLangId == php",
+          "command": "phpGettersSetters.insertGetter",
+          "alt": "phpGettersSetters.insertGetter",
+          "group": "0_phpGettersSetters@1"
+        },
+        {
+          "when": "resourceLangId == php",
+          "command": "phpGettersSetters.insertSetter",
+          "alt": "phpGettersSetters.insertSetter",
+          "group": "0_phpGettersSetters@2"
+        },
+        {
+          "when": "resourceLangId == php",
+          "command": "phpGettersSetters.insertGetterAndSetter",
+          "alt": "phpGettersSetters.insertGetterAndSetter",
+          "group": "0_phpGettersSetters@3"
+        }
+      ]
     }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "test": "npm run compile && node ./node_modules/vscode/bin/test"
+  },
+  "devDependencies": {
+    "@types/mocha": "^2.2.42",
+    "@types/node": "^7.0.43",
+    "typescript": "^2.6.1",
+    "vscode": "^1.1.37"
+  }
 }

--- a/src/Property.ts
+++ b/src/Property.ts
@@ -1,6 +1,6 @@
-"use strict";
+'use strict';
 
-import * as vscode from "vscode";
+import * as vscode from 'vscode';
 
 export default class Property {
     private description: string = null;
@@ -8,17 +8,10 @@ export default class Property {
     private name: string;
     private type: string = null;
     private typeHint: string = null;
-    private pseudoTypes = [
-        "mixed",
-        "number",
-        "callback",
-        "array|object",
-        "void",
-        "null",
-        "integer",
-    ];
+    private pseudoTypes = ['mixed', 'number', 'callback', 'array|object', 'void', 'null', 'integer'];
 
-    public constructor(name: string) {
+    public constructor(name: string)
+    {
         this.name = name;
     }
 
@@ -62,56 +55,36 @@ export default class Property {
         return null;
     }
 
-    static fromEditorPosition(
-        editor: vscode.TextEditor,
-        activePosition: vscode.Position
-    ) {
-        const wordRange =
-            editor.document.getWordRangeAtPosition(activePosition);
+    static fromEditorPosition(editor: vscode.TextEditor, activePosition: vscode.Position) {
+        const wordRange = editor.document.getWordRangeAtPosition(activePosition);
 
-        let selectedWord = undefined;
+        let selectedWord = undefined
 
         if (wordRange !== undefined) {
             // throw new Error('No property found. Please select a property to use this extension.');
             selectedWord = editor.document.getText(wordRange);
-        } else if (selectedWord === undefined || selectedWord[0] !== "$") {
-            const matchWord = editor.document
-                .lineAt(activePosition.line)
-                .text.match(/\$[a-zA-Z_]*/);
+        } else if (selectedWord === undefined || selectedWord[0] !== '$') {
+            const matchWord = editor.document.lineAt(activePosition.line).text.match(/\$[a-zA-Z_]*/);
 
             if (null === matchWord) {
-                throw new Error(
-                    "No property found. Please select a property to use this extension."
-                );
+                throw new Error('No property found. Please select a property to use this extension.');
             }
             selectedWord = matchWord[0];
         } else {
-            throw new Error(
-                "No property found. Please select a property to use this extension."
-            );
+            throw new Error('No property found. Please select a property to use this extension.');
         }
-        let property = new Property(
-            selectedWord.substring(1, selectedWord.length)
-        );
+        let property = new Property(selectedWord.substring(1, selectedWord.length));
 
         const activeLineNumber = activePosition.line;
         const activeLine = editor.document.lineAt(activeLineNumber);
-        const activeLineTokens = activeLine.text.slice(0, -1).split(" ");
-        const typehint =
-            activeLineTokens[activeLineTokens.indexOf(selectedWord) - 1];
+        const activeLineTokens = activeLine.text.slice(0, -1).split(' ');
+        const typehint = activeLineTokens[activeLineTokens.indexOf(selectedWord) - 1];
 
-        if (
-            typehint !== "public" &&
-            typehint !== "private" &&
-            typehint !== "protected"
-        ) {
+        if (typehint !== 'public' && typehint !== 'private' && typehint !== 'protected') {
             property.setType(typehint);
         }
 
-        property.indentation = activeLine.text.substring(
-            0,
-            activeLine.firstNonWhitespaceCharacterIndex
-        );
+        property.indentation = activeLine.text.substring(0, activeLine.firstNonWhitespaceCharacterIndex);
 
         const previousLineNumber = activeLineNumber - 1;
 
@@ -122,7 +95,7 @@ export default class Property {
         const previousLine = editor.document.lineAt(previousLineNumber);
 
         // No doc block found
-        if (!previousLine.text.endsWith("*/")) {
+        if (!previousLine.text.endsWith('*/')) {
             return property;
         }
 
@@ -135,16 +108,16 @@ export default class Property {
             const text = editor.document.lineAt(line).text;
 
             // Reached the end of the doc block
-            if (text.includes("/**") || !text.includes("*")) {
+            if (text.includes('/**') || !text.includes('*')) {
                 break;
             }
 
             // Remove spaces & tabs
-            const lineParts = text.split(" ").filter(function (value) {
-                return value !== "" && value !== "\t" && value !== "*";
+            const lineParts = text.split(' ').filter(function(value){
+                return value !== '' && value !== "\t" && value !== "*";
             });
 
-            const varPosition = lineParts.indexOf("@var");
+            const varPosition = lineParts.indexOf('@var');
 
             // Found @var line
             if (-1 !== varPosition) {
@@ -161,7 +134,7 @@ export default class Property {
 
             const posibleDescription = lineParts.join(` `);
 
-            if (posibleDescription[0] !== "@") {
+            if (posibleDescription[0] !== '@') {
                 property.description = posibleDescription;
             }
         }
@@ -173,73 +146,66 @@ export default class Property {
         return Property.fromEditorPosition(editor, editor.selection.active);
     }
 
-    generateMethodDescription(prefix: string): string {
+    generateMethodDescription(prefix : string) : string {
         if (this.description) {
-            return (
-                prefix +
-                this.description.charAt(0).toLowerCase() +
-                this.description.substring(1)
-            );
+            return prefix + this.description.charAt(0).toLowerCase() + this.description.substring(1);
         }
 
         return prefix + `the value of ` + this.name;
     }
 
-    generateMethodName(prefix: string): string {
-        let name = this.name
-            .split("_")
-            .map((str) => str.charAt(0).toLocaleUpperCase() + str.slice(1))
-            .join("");
+    generateMethodName(prefix : string) : string {
+        let name = this.name.split('_')
+            .map(str => str.charAt(0).toLocaleUpperCase() + str.slice(1))
+            .join('');
         return prefix + name;
     }
 
-    getDescription(): string {
+    getDescription() : string {
         return this.description;
     }
 
-    getIndentation(): string {
+    getIndentation() : string {
         return this.indentation;
     }
 
-    getName(): string {
+    getName() : string {
         return this.name;
     }
 
-    getterDescription(): string {
-        return this.generateMethodDescription("Get ");
+    getterDescription() : string {
+        return this.generateMethodDescription('Get ');
     }
 
-    getterName(): string {
-        return this.generateMethodName(this.type === "bool" ? "is" : "get");
+    getterName() : string {
+        return this.generateMethodName(this.type === 'bool' ? 'is' : 'get');
     }
 
-    getType(): string {
+    getType() : string {
         return this.type;
     }
 
-    getTypeHint(): string {
+    getTypeHint() : string {
         return this.typeHint;
     }
 
-    isValidTypeHint(type: string) {
-        return (
-            -1 === type.indexOf("|") && -1 === this.pseudoTypes.indexOf(type)
-        );
+    isValidTypeHint(type : string) {
+        return (-1 === type.indexOf('|') && -1 === this.pseudoTypes.indexOf(type));
     }
 
-    setterDescription(): string {
-        return this.generateMethodDescription("Set ");
+    setterDescription() : string {
+        return this.generateMethodDescription('Set ');
     }
 
-    setterName(): string {
-        return this.generateMethodName("set");
+    setterName() : string {
+        return this.generateMethodName('set');
     }
 
-    setType(type: string) {
+    setType(type : string) {
         this.type = type;
 
-        if (type.indexOf("[]") > 0) {
-            type = "array";
+        if (type.indexOf('[]') > 0) {
+            type = 'array';
         }
 
         if (this.isValidTypeHint(type)) {

--- a/src/Property.ts
+++ b/src/Property.ts
@@ -3,235 +3,247 @@
 import * as vscode from "vscode";
 
 export default class Property {
-  private description: string = null;
-  private indentation: string;
-  private name: string;
-  private type: string = null;
-  private typeHint: string = null;
-  private pseudoTypes = [
-    "mixed",
-    "number",
-    "callback",
-    "array|object",
-    "void",
-    "null",
-    "integer",
-  ];
+    private description: string = null;
+    private indentation: string;
+    private name: string;
+    private type: string = null;
+    private typeHint: string = null;
+    private pseudoTypes = [
+        "mixed",
+        "number",
+        "callback",
+        "array|object",
+        "void",
+        "null",
+        "integer",
+    ];
 
-  public constructor(name: string) {
-    this.name = name;
-  }
-
-  static isAProperty(line: vscode.TextLine) {
-    const text = line.text;
-
-    if (
-      /^\s*(private|public|protected\b)\s\$[a-zA-Z_]+[a-zA-Z_0-9]*/.test(text)
-    ) {
-      return true;
+    public constructor(name: string) {
+        this.name = name;
     }
 
-    return false;
-  }
+    /**
+     * Check if a property is defined in the provided line
+     * @param line Line of the editor.document to search for a property
+     * @returns Boolean. True if the line defines a property, false otherwise
+     */
+    static isAProperty(line: vscode.TextLine) {
+        const text = line.text;
 
-  static fromLine(
-    editor: vscode.TextEditor,
-    line: vscode.TextLine
-  ): Property | null {
-    const position = new vscode.Position(
-      line.lineNumber,
-      line.range.end.character - 1
-    );
-
-    if (Property.isAProperty(line))
-      return Property.fromEditorPosition(editor, position);
-
-    return null;
-  }
-
-  static fromEditorPosition(
-    editor: vscode.TextEditor,
-    activePosition: vscode.Position
-  ) {
-    try {
-      const wordRange = editor.document.getWordRangeAtPosition(activePosition);
-
-      let selectedWord = undefined;
-
-      if (wordRange !== undefined) {
-        // throw new Error('No property found. Please select a property to use this extension.');
-        selectedWord = editor.document.getText(wordRange);
-      } else if (selectedWord === undefined || selectedWord[0] !== "$") {
-        const matchWord = editor.document
-          .lineAt(activePosition.line)
-          .text.match(/\$[a-zA-Z_]*/);
-
-        if (null === matchWord) {
-          throw new Error(
-            "No property found. Please select a property to use this extension."
-          );
+        if (
+            /^\s*(private|public|protected\b)\s\$[a-zA-Z_]+[a-zA-Z_0-9]*/.test(
+                text
+            )
+        ) {
+            return true;
         }
-        selectedWord = matchWord[0];
-      } else {
-        throw new Error(
-          "No property found. Please select a property to use this extension."
+
+        return false;
+    }
+
+    /**
+     * Search for and get the property in a line of the provided document if exists
+     * @param editor Vscode active text editor
+     * @param line Line of the editor.document to search for a property
+     * @returns Property object if found, null in other case
+     */
+    static fromLine(
+        editor: vscode.TextEditor,
+        line: vscode.TextLine
+    ): Property | null {
+        const position = new vscode.Position(
+            line.lineNumber,
+            line.range.end.character - 1 // Avoid semicolon
         );
-      }
-      let property = new Property(
-        selectedWord.substring(1, selectedWord.length)
-      );
 
-      const activeLineNumber = activePosition.line;
-      const activeLine = editor.document.lineAt(activeLineNumber);
-      const activeLineTokens = activeLine.text.slice(0, -1).split(" ");
-      const typehint =
-        activeLineTokens[activeLineTokens.indexOf(selectedWord) - 1];
+        if (Property.isAProperty(line))
+            return Property.fromEditorPosition(editor, position);
 
-      if (
-        typehint !== "public" &&
-        typehint !== "private" &&
-        typehint !== "protected"
-      ) {
-        property.setType(typehint);
-      }
+        return null;
+    }
 
-      property.indentation = activeLine.text.substring(
-        0,
-        activeLine.firstNonWhitespaceCharacterIndex
-      );
+    static fromEditorPosition(
+        editor: vscode.TextEditor,
+        activePosition: vscode.Position
+    ) {
+        const wordRange =
+            editor.document.getWordRangeAtPosition(activePosition);
 
-      const previousLineNumber = activeLineNumber - 1;
+        let selectedWord = undefined;
 
-      if (previousLineNumber <= 0) {
+        if (wordRange !== undefined) {
+            // throw new Error('No property found. Please select a property to use this extension.');
+            selectedWord = editor.document.getText(wordRange);
+        } else if (selectedWord === undefined || selectedWord[0] !== "$") {
+            const matchWord = editor.document
+                .lineAt(activePosition.line)
+                .text.match(/\$[a-zA-Z_]*/);
+
+            if (null === matchWord) {
+                throw new Error(
+                    "No property found. Please select a property to use this extension."
+                );
+            }
+            selectedWord = matchWord[0];
+        } else {
+            throw new Error(
+                "No property found. Please select a property to use this extension."
+            );
+        }
+        let property = new Property(
+            selectedWord.substring(1, selectedWord.length)
+        );
+
+        const activeLineNumber = activePosition.line;
+        const activeLine = editor.document.lineAt(activeLineNumber);
+        const activeLineTokens = activeLine.text.slice(0, -1).split(" ");
+        const typehint =
+            activeLineTokens[activeLineTokens.indexOf(selectedWord) - 1];
+
+        if (
+            typehint !== "public" &&
+            typehint !== "private" &&
+            typehint !== "protected"
+        ) {
+            property.setType(typehint);
+        }
+
+        property.indentation = activeLine.text.substring(
+            0,
+            activeLine.firstNonWhitespaceCharacterIndex
+        );
+
+        const previousLineNumber = activeLineNumber - 1;
+
+        if (previousLineNumber <= 0) {
+            return property;
+        }
+
+        const previousLine = editor.document.lineAt(previousLineNumber);
+
+        // No doc block found
+        if (!previousLine.text.endsWith("*/")) {
+            return property;
+        }
+
+        for (let line = previousLineNumber - 1; line > 0; line--) {
+            // Everything found
+            if (property.name && property.type && property.description) {
+                break;
+            }
+
+            const text = editor.document.lineAt(line).text;
+
+            // Reached the end of the doc block
+            if (text.includes("/**") || !text.includes("*")) {
+                break;
+            }
+
+            // Remove spaces & tabs
+            const lineParts = text.split(" ").filter(function (value) {
+                return value !== "" && value !== "\t" && value !== "*";
+            });
+
+            const varPosition = lineParts.indexOf("@var");
+
+            // Found @var line
+            if (-1 !== varPosition) {
+                property.setType(lineParts[varPosition + 1]);
+
+                var descriptionParts = lineParts.slice(varPosition + 2);
+
+                if (descriptionParts.length) {
+                    property.description = descriptionParts.join(` `);
+                }
+
+                continue;
+            }
+
+            const posibleDescription = lineParts.join(` `);
+
+            if (posibleDescription[0] !== "@") {
+                property.description = posibleDescription;
+            }
+        }
+
         return property;
-      }
-
-      const previousLine = editor.document.lineAt(previousLineNumber);
-
-      // No doc block found
-      if (!previousLine.text.endsWith("*/")) {
-        return property;
-      }
-
-      for (let line = previousLineNumber - 1; line > 0; line--) {
-        // Everything found
-        if (property.name && property.type && property.description) {
-          break;
-        }
-
-        const text = editor.document.lineAt(line).text;
-
-        // Reached the end of the doc block
-        if (text.includes("/**") || !text.includes("*")) {
-          break;
-        }
-
-        // Remove spaces & tabs
-        const lineParts = text.split(" ").filter(function (value) {
-          return value !== "" && value !== "\t" && value !== "*";
-        });
-
-        const varPosition = lineParts.indexOf("@var");
-
-        // Found @var line
-        if (-1 !== varPosition) {
-          property.setType(lineParts[varPosition + 1]);
-
-          var descriptionParts = lineParts.slice(varPosition + 2);
-
-          if (descriptionParts.length) {
-            property.description = descriptionParts.join(` `);
-          }
-
-          continue;
-        }
-
-        const posibleDescription = lineParts.join(` `);
-
-        if (posibleDescription[0] !== "@") {
-          property.description = posibleDescription;
-        }
-      }
-
-      return property;
-    } catch (e) {
-      console.error(e);
-    }
-  }
-
-  static fromEditorSelection(editor: vscode.TextEditor) {
-    return Property.fromEditorPosition(editor, editor.selection.active);
-  }
-
-  generateMethodDescription(prefix: string): string {
-    if (this.description) {
-      return (
-        prefix +
-        this.description.charAt(0).toLowerCase() +
-        this.description.substring(1)
-      );
     }
 
-    return prefix + `the value of ` + this.name;
-  }
-
-  generateMethodName(prefix: string): string {
-    let name = this.name
-      .split("_")
-      .map((str) => str.charAt(0).toLocaleUpperCase() + str.slice(1))
-      .join("");
-    return prefix + name;
-  }
-
-  getDescription(): string {
-    return this.description;
-  }
-
-  getIndentation(): string {
-    return this.indentation;
-  }
-
-  getName(): string {
-    return this.name;
-  }
-
-  getterDescription(): string {
-    return this.generateMethodDescription("Get ");
-  }
-
-  getterName(): string {
-    return this.generateMethodName(this.type === "bool" ? "is" : "get");
-  }
-
-  getType(): string {
-    return this.type;
-  }
-
-  getTypeHint(): string {
-    return this.typeHint;
-  }
-
-  isValidTypeHint(type: string) {
-    return -1 === type.indexOf("|") && -1 === this.pseudoTypes.indexOf(type);
-  }
-
-  setterDescription(): string {
-    return this.generateMethodDescription("Set ");
-  }
-
-  setterName(): string {
-    return this.generateMethodName("set");
-  }
-
-  setType(type: string) {
-    this.type = type;
-
-    if (type.indexOf("[]") > 0) {
-      type = "array";
+    static fromEditorSelection(editor: vscode.TextEditor) {
+        return Property.fromEditorPosition(editor, editor.selection.active);
     }
 
-    if (this.isValidTypeHint(type)) {
-      this.typeHint = type;
+    generateMethodDescription(prefix: string): string {
+        if (this.description) {
+            return (
+                prefix +
+                this.description.charAt(0).toLowerCase() +
+                this.description.substring(1)
+            );
+        }
+
+        return prefix + `the value of ` + this.name;
     }
-  }
+
+    generateMethodName(prefix: string): string {
+        let name = this.name
+            .split("_")
+            .map((str) => str.charAt(0).toLocaleUpperCase() + str.slice(1))
+            .join("");
+        return prefix + name;
+    }
+
+    getDescription(): string {
+        return this.description;
+    }
+
+    getIndentation(): string {
+        return this.indentation;
+    }
+
+    getName(): string {
+        return this.name;
+    }
+
+    getterDescription(): string {
+        return this.generateMethodDescription("Get ");
+    }
+
+    getterName(): string {
+        return this.generateMethodName(this.type === "bool" ? "is" : "get");
+    }
+
+    getType(): string {
+        return this.type;
+    }
+
+    getTypeHint(): string {
+        return this.typeHint;
+    }
+
+    isValidTypeHint(type: string) {
+        return (
+            -1 === type.indexOf("|") && -1 === this.pseudoTypes.indexOf(type)
+        );
+    }
+
+    setterDescription(): string {
+        return this.generateMethodDescription("Set ");
+    }
+
+    setterName(): string {
+        return this.generateMethodName("set");
+    }
+
+    setType(type: string) {
+        this.type = type;
+
+        if (type.indexOf("[]") > 0) {
+            type = "array";
+        }
+
+        if (this.isValidTypeHint(type)) {
+            this.typeHint = type;
+        }
+    }
 }

--- a/src/Property.ts
+++ b/src/Property.ts
@@ -26,7 +26,7 @@ export default class Property {
     const text = line.text;
 
     if (
-      /^\s*(private|public|protected\b)\s\$[a-zA-Z_]*[a-zA-Z_0-9]*/.test(text)
+      /^\s*(private|public|protected\b)\s\$[a-zA-Z_]+[a-zA-Z_0-9]*/.test(text)
     ) {
       return true;
     }

--- a/src/Property.ts
+++ b/src/Property.ts
@@ -1,176 +1,237 @@
+"use strict";
 
-'use strict';
-
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
 export default class Property {
-    private description: string = null;
-    private indentation: string;
-    private name: string;
-    private type: string = null;
-    private typeHint: string = null;
-    private pseudoTypes = ['mixed', 'number', 'callback', 'array|object', 'void', 'null', 'integer'];
+  private description: string = null;
+  private indentation: string;
+  private name: string;
+  private type: string = null;
+  private typeHint: string = null;
+  private pseudoTypes = [
+    "mixed",
+    "number",
+    "callback",
+    "array|object",
+    "void",
+    "null",
+    "integer",
+  ];
 
-    public constructor(name: string)
-    {
-        this.name = name;
+  public constructor(name: string) {
+    this.name = name;
+  }
+
+  static isAProperty(line: vscode.TextLine) {
+    const text = line.text;
+
+    if (
+      /^\s*(private|public|protected\b)\s\$[a-zA-Z_]*[a-zA-Z_0-9]*/.test(text)
+    ) {
+      return true;
     }
 
-    static fromEditorPosition(editor: vscode.TextEditor, activePosition: vscode.Position) {
-        const wordRange = editor.document.getWordRangeAtPosition(activePosition);
+    return false;
+  }
 
-        let selectedWord = undefined
+  static fromLine(
+    editor: vscode.TextEditor,
+    line: vscode.TextLine
+  ): Property | null {
+    const position = new vscode.Position(
+      line.lineNumber,
+      line.range.end.character - 1
+    );
 
-        if (wordRange !== undefined) {
-            // throw new Error('No property found. Please select a property to use this extension.');
-            selectedWord = editor.document.getText(wordRange);
-        } else if (selectedWord === undefined || selectedWord[0] !== '$') {
-            const matchWord = editor.document.lineAt(activePosition.line).text.match(/\$[a-zA-Z_]*/);
+    if (Property.isAProperty(line))
+      return Property.fromEditorPosition(editor, position);
 
-            if (null === matchWord) {
-                throw new Error('No property found. Please select a property to use this extension.');
-            }
-            selectedWord = matchWord[0];
-        } else {
-            throw new Error('No property found. Please select a property to use this extension.');
+    return null;
+  }
+
+  static fromEditorPosition(
+    editor: vscode.TextEditor,
+    activePosition: vscode.Position
+  ) {
+    try {
+      const wordRange = editor.document.getWordRangeAtPosition(activePosition);
+
+      let selectedWord = undefined;
+
+      if (wordRange !== undefined) {
+        // throw new Error('No property found. Please select a property to use this extension.');
+        selectedWord = editor.document.getText(wordRange);
+      } else if (selectedWord === undefined || selectedWord[0] !== "$") {
+        const matchWord = editor.document
+          .lineAt(activePosition.line)
+          .text.match(/\$[a-zA-Z_]*/);
+
+        if (null === matchWord) {
+          throw new Error(
+            "No property found. Please select a property to use this extension."
+          );
         }
-        let property = new Property(selectedWord.substring(1, selectedWord.length));
+        selectedWord = matchWord[0];
+      } else {
+        throw new Error(
+          "No property found. Please select a property to use this extension."
+        );
+      }
+      let property = new Property(
+        selectedWord.substring(1, selectedWord.length)
+      );
 
-        const activeLineNumber = activePosition.line;
-        const activeLine = editor.document.lineAt(activeLineNumber);
-        const activeLineTokens = activeLine.text.slice(0, -1).split(' ');
-        const typehint = activeLineTokens[activeLineTokens.indexOf(selectedWord) - 1];
+      const activeLineNumber = activePosition.line;
+      const activeLine = editor.document.lineAt(activeLineNumber);
+      const activeLineTokens = activeLine.text.slice(0, -1).split(" ");
+      const typehint =
+        activeLineTokens[activeLineTokens.indexOf(selectedWord) - 1];
 
-        if (typehint !== 'public' && typehint !== 'private' && typehint !== 'protected') {
-            property.setType(typehint);
-        }
+      if (
+        typehint !== "public" &&
+        typehint !== "private" &&
+        typehint !== "protected"
+      ) {
+        property.setType(typehint);
+      }
 
-        property.indentation = activeLine.text.substring(0, activeLine.firstNonWhitespaceCharacterIndex);
+      property.indentation = activeLine.text.substring(
+        0,
+        activeLine.firstNonWhitespaceCharacterIndex
+      );
 
-        const previousLineNumber = activeLineNumber - 1;
+      const previousLineNumber = activeLineNumber - 1;
 
-        if (previousLineNumber <= 0) {
-            return property;
-        }
-
-        const previousLine = editor.document.lineAt(previousLineNumber);
-
-        // No doc block found
-        if (!previousLine.text.endsWith('*/')) {
-            return property;
-        }
-
-        for (let line = previousLineNumber - 1; line > 0; line--) {
-            // Everything found
-            if (property.name && property.type && property.description) {
-                break;
-            }
-
-            const text = editor.document.lineAt(line).text;
-
-            // Reached the end of the doc block
-            if (text.includes('/**') || !text.includes('*')) {
-                break;
-            }
-
-            // Remove spaces & tabs
-            const lineParts = text.split(' ').filter(function(value){
-                return value !== '' && value !== "\t" && value !== "*";
-            });
-
-            const varPosition = lineParts.indexOf('@var');
-
-            // Found @var line
-            if (-1 !== varPosition) {
-                property.setType(lineParts[varPosition + 1]);
-
-                var descriptionParts = lineParts.slice(varPosition + 2);
-
-                if (descriptionParts.length) {
-                    property.description = descriptionParts.join(` `);
-                }
-
-                continue;
-            }
-
-            const posibleDescription = lineParts.join(` `);
-
-            if (posibleDescription[0] !== '@') {
-                property.description = posibleDescription;
-            }
-        }
-
+      if (previousLineNumber <= 0) {
         return property;
-    }
+      }
 
-    static fromEditorSelection(editor: vscode.TextEditor) {
-        return Property.fromEditorPosition(editor, editor.selection.active);
-    }
+      const previousLine = editor.document.lineAt(previousLineNumber);
 
-    generateMethodDescription(prefix : string) : string {
-        if (this.description) {
-            return prefix + this.description.charAt(0).toLowerCase() + this.description.substring(1);
+      // No doc block found
+      if (!previousLine.text.endsWith("*/")) {
+        return property;
+      }
+
+      for (let line = previousLineNumber - 1; line > 0; line--) {
+        // Everything found
+        if (property.name && property.type && property.description) {
+          break;
         }
 
-        return prefix + `the value of ` + this.name;
-    }
+        const text = editor.document.lineAt(line).text;
 
-    generateMethodName(prefix : string) : string {
-        let name = this.name.split('_')
-            .map(str => str.charAt(0).toLocaleUpperCase() + str.slice(1))
-            .join('');
-        return prefix + name;
-    }
-
-    getDescription() : string {
-        return this.description;
-    }
-
-    getIndentation() : string {
-        return this.indentation;
-    }
-
-    getName() : string {
-        return this.name;
-    }
-
-    getterDescription() : string {
-        return this.generateMethodDescription('Get ');
-    }
-
-    getterName() : string {
-        return this.generateMethodName(this.type === 'bool' ? 'is' : 'get');
-    }
-
-    getType() : string {
-        return this.type;
-    }
-
-    getTypeHint() : string {
-        return this.typeHint;
-    }
-
-    isValidTypeHint(type : string) {
-        return (-1 === type.indexOf('|') && -1 === this.pseudoTypes.indexOf(type));
-    }
-
-    setterDescription() : string {
-        return this.generateMethodDescription('Set ');
-    }
-
-    setterName() : string {
-        return this.generateMethodName('set');
-    }
-
-    setType(type : string) {
-        this.type = type;
-
-        if (type.indexOf('[]') > 0) {
-            type = 'array';
+        // Reached the end of the doc block
+        if (text.includes("/**") || !text.includes("*")) {
+          break;
         }
 
-        if (this.isValidTypeHint(type)) {
-            this.typeHint = type;
+        // Remove spaces & tabs
+        const lineParts = text.split(" ").filter(function (value) {
+          return value !== "" && value !== "\t" && value !== "*";
+        });
+
+        const varPosition = lineParts.indexOf("@var");
+
+        // Found @var line
+        if (-1 !== varPosition) {
+          property.setType(lineParts[varPosition + 1]);
+
+          var descriptionParts = lineParts.slice(varPosition + 2);
+
+          if (descriptionParts.length) {
+            property.description = descriptionParts.join(` `);
+          }
+
+          continue;
         }
+
+        const posibleDescription = lineParts.join(` `);
+
+        if (posibleDescription[0] !== "@") {
+          property.description = posibleDescription;
+        }
+      }
+
+      return property;
+    } catch (e) {
+      console.error(e);
     }
+  }
+
+  static fromEditorSelection(editor: vscode.TextEditor) {
+    return Property.fromEditorPosition(editor, editor.selection.active);
+  }
+
+  generateMethodDescription(prefix: string): string {
+    if (this.description) {
+      return (
+        prefix +
+        this.description.charAt(0).toLowerCase() +
+        this.description.substring(1)
+      );
+    }
+
+    return prefix + `the value of ` + this.name;
+  }
+
+  generateMethodName(prefix: string): string {
+    let name = this.name
+      .split("_")
+      .map((str) => str.charAt(0).toLocaleUpperCase() + str.slice(1))
+      .join("");
+    return prefix + name;
+  }
+
+  getDescription(): string {
+    return this.description;
+  }
+
+  getIndentation(): string {
+    return this.indentation;
+  }
+
+  getName(): string {
+    return this.name;
+  }
+
+  getterDescription(): string {
+    return this.generateMethodDescription("Get ");
+  }
+
+  getterName(): string {
+    return this.generateMethodName(this.type === "bool" ? "is" : "get");
+  }
+
+  getType(): string {
+    return this.type;
+  }
+
+  getTypeHint(): string {
+    return this.typeHint;
+  }
+
+  isValidTypeHint(type: string) {
+    return -1 === type.indexOf("|") && -1 === this.pseudoTypes.indexOf(type);
+  }
+
+  setterDescription(): string {
+    return this.generateMethodDescription("Set ");
+  }
+
+  setterName(): string {
+    return this.generateMethodName("set");
+  }
+
+  setType(type: string) {
+    this.type = type;
+
+    if (type.indexOf("[]") > 0) {
+      type = "array";
+    }
+
+    if (this.isValidTypeHint(type)) {
+      this.typeHint = type;
+    }
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,10 @@
-"use strict";
+'use strict';
 
-import * as vscode from "vscode";
+import * as vscode from 'vscode';
 import Redirector from "./Redirector";
 import Property from "./Property";
 import Configuration from "./Configuration";
-import TemplatesManager from "./TemplatesManager";
+import TemplatesManager from './TemplatesManager';
 
 class Resolver {
     config: Configuration;
@@ -13,17 +13,18 @@ class Resolver {
     /**
      * Types that won't be recognised as valid type hints
      */
-    pseudoTypes = ["mixed", "number", "callback", "object", "void"];
+    pseudoTypes = ['mixed', 'number', 'callback', 'object', 'void'];
 
-    public constructor() {
+    public constructor()
+    {
         const editor = this.activeEditor();
 
-        if (editor.document.languageId !== "php") {
-            throw new Error("Not a PHP file.");
+        if (editor.document.languageId !== 'php') {
+            throw new Error('Not a PHP file.');
         }
 
-        this.config = new Configuration();
-        this.templatesManager = new TemplatesManager();
+        this.config = new Configuration;
+        this.templatesManager = new TemplatesManager;
     }
 
     activeEditor() {
@@ -33,15 +34,11 @@ class Resolver {
     closingClassLine() {
         const editor = this.activeEditor();
 
-        for (
-            let lineNumber = editor.document.lineCount - 1;
-            lineNumber > 0;
-            lineNumber--
-        ) {
+        for (let lineNumber = editor.document.lineCount - 1; lineNumber > 0; lineNumber--) {
             const line = editor.document.lineAt(lineNumber);
             const text = line.text.trim();
 
-            if (text.startsWith("}")) {
+            if (text.startsWith('}')) {
                 return line;
             }
         }
@@ -52,16 +49,13 @@ class Resolver {
     insertGetter() {
         const editor = this.activeEditor();
         let property = null;
-        let content = "";
+        let content = '';
 
         for (let index = 0; index < editor.selections.length; index++) {
             const selection = editor.selections[index];
 
             try {
-                property = Property.fromEditorPosition(
-                    editor,
-                    selection.active
-                );
+                property = Property.fromEditorPosition(editor, selection.active);
             } catch (error) {
                 this.showErrorMessage(error.message);
                 return null;
@@ -73,26 +67,22 @@ class Resolver {
         this.renderTemplate(content);
     }
 
-    insertGetterAndSetter() {
+    insertGetterAndSetter(){
         const editor = this.activeEditor();
         let property = null;
-        let content = "";
+        let content = '';
 
         for (let index = 0; index < editor.selections.length; index++) {
             const selection = editor.selections[index];
 
             try {
-                property = Property.fromEditorPosition(
-                    editor,
-                    selection.active
-                );
+                property = Property.fromEditorPosition(editor, selection.active);
             } catch (error) {
                 this.showErrorMessage(error.message);
                 return null;
             }
 
-            content +=
-                this.getterTemplate(property) + this.setterTemplate(property);
+            content += this.getterTemplate(property) + this.setterTemplate(property);
         }
 
         this.renderTemplate(content);
@@ -101,16 +91,13 @@ class Resolver {
     insertSetter() {
         const editor = this.activeEditor();
         let property = null;
-        let content = "";
+        let content = '';
 
         for (let index = 0; index < editor.selections.length; index++) {
             const selection = editor.selections[index];
 
             try {
-                property = Property.fromEditorPosition(
-                    editor,
-                    selection.active
-                );
+                property = Property.fromEditorPosition(editor, selection.active);
             } catch (error) {
                 this.showErrorMessage(error.message);
                 return null;
@@ -129,12 +116,12 @@ class Resolver {
      */
     insertAllGetterAndSetter() {
         const editor = this.activeEditor();
-        let content = "";
+        let content = '';
 
         for (let i = 0; i < editor.document.lineCount; i++) {
             const line = editor.document.lineAt(i);
             // End loop asap
-            if (line.text == "") continue;
+            if (line.text == '') continue;
 
             let property;
             try {
@@ -156,10 +143,8 @@ class Resolver {
         const description = prop.getDescription();
         const tab = prop.getIndentation();
         const type = prop.getType();
-        const spacesAfterReturn = Array(
-            this.config.getInt("spacesAfterReturn", 2) + 1
-        ).join(" ");
-        const templateFile = this.config.get("getterTemplate", "getter.js");
+        const spacesAfterReturn = Array(this.config.getInt('spacesAfterReturn', 2) + 1).join(' ');
+        const templateFile = this.config.get('getterTemplate', 'getter.js');
 
         if (this.templatesManager.exists(templateFile)) {
             const template = require(this.templatesManager.path(templateFile));
@@ -167,31 +152,17 @@ class Resolver {
             return template(prop);
         }
 
-        return (
-            `\n` +
-            tab +
-            `/**\n` +
-            tab +
-            ` * ` +
-            prop.getterDescription() +
-            `\n` +
-            (type ? tab + ` *\n` : ``) +
-            (type ? tab + ` * @return` + spacesAfterReturn + type + `\n` : ``) +
-            tab +
-            ` */\n` +
-            tab +
-            `public function ` +
-            prop.getterName() +
-            `()\n` +
-            tab +
-            `{\n` +
-            tab +
-            tab +
-            `return $this->` +
-            name +
-            `;\n` +
-            tab +
-            `}\n`
+        return  (
+            `\n`
+            + tab + `/**\n`
+            + tab + ` * ` + prop.getterDescription() + `\n`
+            + (type ? tab + ` *\n` : ``)
+            + (type ? tab + ` * @return` + spacesAfterReturn + type + `\n` : ``)
+            + tab + ` */\n`
+            + tab + `public function ` + prop.getterName() + `()\n`
+            + tab + `{\n`
+            + tab + tab + `return $this->` + name + `;\n`
+            + tab + `}\n`
         );
     }
 
@@ -201,17 +172,11 @@ class Resolver {
         const tab = prop.getIndentation();
         const type = prop.getType();
         const typeHint = prop.getTypeHint();
-        const spacesAfterParam = Array(
-            this.config.getInt("spacesAfterParam", 2) + 1
-        ).join(" ");
-        const spacesAfterParamVar = Array(
-            this.config.getInt("spacesAfterParamVar", 2) + 1
-        ).join(" ");
-        const spacesAfterReturn = Array(
-            this.config.getInt("spacesAfterReturn", 2) + 1
-        ).join(" ");
+        const spacesAfterParam = Array(this.config.getInt('spacesAfterParam', 2) + 1).join(' ');
+        const spacesAfterParamVar = Array(this.config.getInt('spacesAfterParamVar', 2) + 1).join(' ');
+        const spacesAfterReturn = Array(this.config.getInt('spacesAfterReturn', 2) + 1).join(' ');
 
-        const templateFile = this.config.get("setterTemplate", "setter.js");
+        const templateFile = this.config.get('setterTemplate', 'setter.js');
 
         if (this.templatesManager.exists(templateFile)) {
             const template = require(this.templatesManager.path(templateFile));
@@ -220,141 +185,85 @@ class Resolver {
         }
 
         return (
-            `\n` +
-            tab +
-            `/**\n` +
-            tab +
-            ` * ` +
-            prop.setterDescription() +
-            `\n` +
-            (type ? tab + ` *\n` : ``) +
-            (type
-                ? tab +
-                  ` * @param` +
-                  spacesAfterParam +
-                  type +
-                  spacesAfterParamVar +
-                  `$` +
-                  name +
-                  (description ? `  ` + description : ``) +
-                  `\n`
-                : ``) +
-            tab +
-            ` *\n` +
-            tab +
-            ` * @return` +
-            spacesAfterReturn +
-            `self\n` +
-            tab +
-            ` */\n` +
-            tab +
-            `public function ` +
-            prop.setterName() +
-            `(` +
-            (typeHint ? typeHint + ` ` : ``) +
-            `$` +
-            name +
-            `)\n` +
-            tab +
-            `{\n` +
-            tab +
-            tab +
-            `$this->` +
-            name +
-            ` = $` +
-            name +
-            `;\n` +
-            `\n` +
-            tab +
-            tab +
-            `return $this;\n` +
-            tab +
-            `}\n`
+            `\n`
+            + tab + `/**\n`
+            + tab + ` * ` + prop.setterDescription() + `\n`
+            + (type ? tab + ` *\n` : ``)
+            + (type ? tab + ` * @param` + spacesAfterParam + type + spacesAfterParamVar + `$` + name + (description ? `  ` + description : ``) + `\n` : ``)
+            + tab + ` *\n`
+            + tab + ` * @return` + spacesAfterReturn + `self\n`
+            + tab + ` */\n`
+            + tab + `public function ` + prop.setterName() + `(` + (typeHint ? typeHint + ` ` : ``) + `$` + name + `)\n`
+            + tab+ `{\n`
+            + tab + tab + `$this->` + name + ` = $` + name + `;\n`
+            + `\n`
+            + tab + tab + `return $this;\n`
+            + tab + `}\n`
         );
     }
 
     renderTemplate(template: string) {
         if (!template) {
-            this.showErrorMessage("Missing template to render.");
+            this.showErrorMessage('Missing template to render.');
             return;
         }
 
         let insertLine = this.insertLine();
 
         if (!insertLine) {
-            this.showErrorMessage("Unable to detect insert line for template.");
+            this.showErrorMessage('Unable to detect insert line for template.');
             return;
         }
 
         const editor = this.activeEditor();
         let resolver = this;
 
-        editor
-            .edit(function (edit: vscode.TextEditorEdit) {
-                edit.replace(
-                    new vscode.Position(insertLine.lineNumber, 0),
-                    template
-                );
-            })
-            .then(
-                (success) => {
-                    if (resolver.isRedirectEnabled() && success) {
-                        const redirector = new Redirector(editor);
-                        redirector.goToLine(
-                            this.closingClassLine().lineNumber - 1
-                        );
-                    }
-                },
-                (error) => {
-                    this.showErrorMessage(
-                        `Error generating functions: ` + error
-                    );
-                }
+        editor.edit(function(edit: vscode.TextEditorEdit){
+            edit.replace(
+                new vscode.Position(insertLine.lineNumber, 0),
+                template
             );
+        }).then(
+            success => {
+                if (resolver.isRedirectEnabled() && success) {
+                    const redirector = new Redirector(editor);
+                    redirector.goToLine(this.closingClassLine().lineNumber - 1);
+                }
+            },
+            error => {
+                this.showErrorMessage(`Error generating functions: ` + error);
+            }
+        );
     }
 
     insertLine() {
         return this.closingClassLine();
     }
 
-    isRedirectEnabled(): boolean {
-        return true === this.config.get("redirect", true);
+    isRedirectEnabled() : boolean {
+        return true === this.config.get('redirect', true);
     }
 
     showErrorMessage(message: string) {
-        message =
-            "phpGettersSetters error: " + message.replace(/\$\(.+?\)\s\s/, "");
+        message = 'phpGettersSetters error: ' + message.replace(/\$\(.+?\)\s\s/, '');
 
         vscode.window.showErrorMessage(message);
     }
 
     showInformationMessage(message: string) {
-        message =
-            "phpGettersSetters info: " + message.replace(/\$\(.+?\)\s\s/, "");
+        message = 'phpGettersSetters info: ' + message.replace(/\$\(.+?\)\s\s/, '');
 
         vscode.window.showInformationMessage(message);
     }
 }
 
 function activate(context: vscode.ExtensionContext) {
-    let resolver = new Resolver();
+    let resolver = new Resolver;
 
-    let insertGetter = vscode.commands.registerCommand(
-        "phpGettersSetters.insertGetter",
-        () => resolver.insertGetter()
-    );
-    let insertSetter = vscode.commands.registerCommand(
-        "phpGettersSetters.insertSetter",
-        () => resolver.insertSetter()
-    );
-    let insertGetterAndSetter = vscode.commands.registerCommand(
-        "phpGettersSetters.insertGetterAndSetter",
-        () => resolver.insertGetterAndSetter()
-    );
-    let insertAllGetterAndSetter = vscode.commands.registerCommand(
-        "phpGettersSetters.insertAllGetterAndSetter",
-        () => resolver.insertAllGetterAndSetter()
-    );
+    let insertGetter = vscode.commands.registerCommand('phpGettersSetters.insertGetter', () => resolver.insertGetter());
+    let insertSetter = vscode.commands.registerCommand('phpGettersSetters.insertSetter', () => resolver.insertSetter());
+    let insertGetterAndSetter = vscode.commands.registerCommand('phpGettersSetters.insertGetterAndSetter', () => resolver.insertGetterAndSetter());
+    let insertAllGetterAndSetter = vscode.commands.registerCommand('phpGettersSetters.insertAllGetterAndSetter', () => resolver.insertAllGetterAndSetter());
 
     context.subscriptions.push(insertGetter);
     context.subscriptions.push(insertSetter);
@@ -362,7 +271,8 @@ function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(insertAllGetterAndSetter);
 }
 
-function deactivate() {}
+function deactivate() {
+}
 
 exports.activate = activate;
 exports.deactivate = deactivate;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,340 +7,359 @@ import Configuration from "./Configuration";
 import TemplatesManager from "./TemplatesManager";
 
 class Resolver {
-  config: Configuration;
-  templatesManager: TemplatesManager;
+    config: Configuration;
+    templatesManager: TemplatesManager;
 
-  /**
-   * Types that won't be recognised as valid type hints
-   */
-  pseudoTypes = ["mixed", "number", "callback", "object", "void"];
+    /**
+     * Types that won't be recognised as valid type hints
+     */
+    pseudoTypes = ["mixed", "number", "callback", "object", "void"];
 
-  public constructor() {
-    const editor = this.activeEditor();
+    public constructor() {
+        const editor = this.activeEditor();
 
-    if (editor.document.languageId !== "php") {
-      throw new Error("Not a PHP file.");
-    }
-
-    this.config = new Configuration();
-    this.templatesManager = new TemplatesManager();
-  }
-
-  activeEditor() {
-    return vscode.window.activeTextEditor;
-  }
-
-  closingClassLine() {
-    const editor = this.activeEditor();
-
-    for (
-      let lineNumber = editor.document.lineCount - 1;
-      lineNumber > 0;
-      lineNumber--
-    ) {
-      const line = editor.document.lineAt(lineNumber);
-      const text = line.text.trim();
-
-      if (text.startsWith("}")) {
-        return line;
-      }
-    }
-
-    return null;
-  }
-
-  insertGetter() {
-    const editor = this.activeEditor();
-    let property = null;
-    let content = "";
-
-    for (let index = 0; index < editor.selections.length; index++) {
-      const selection = editor.selections[index];
-
-      try {
-        property = Property.fromEditorPosition(editor, selection.active);
-      } catch (error) {
-        this.showErrorMessage(error.message);
-        return null;
-      }
-
-      content += this.getterTemplate(property);
-    }
-
-    this.renderTemplate(content);
-  }
-
-  insertGetterAndSetter() {
-    const editor = this.activeEditor();
-    let property = null;
-    let content = "";
-
-    for (let index = 0; index < editor.selections.length; index++) {
-      const selection = editor.selections[index];
-
-      try {
-        property = Property.fromEditorPosition(editor, selection.active);
-      } catch (error) {
-        this.showErrorMessage(error.message);
-        return null;
-      }
-
-      content += this.getterTemplate(property) + this.setterTemplate(property);
-    }
-
-    this.renderTemplate(content);
-  }
-
-  insertSetter() {
-    const editor = this.activeEditor();
-    let property = null;
-    let content = "";
-
-    for (let index = 0; index < editor.selections.length; index++) {
-      const selection = editor.selections[index];
-
-      try {
-        property = Property.fromEditorPosition(editor, selection.active);
-      } catch (error) {
-        this.showErrorMessage(error.message);
-        return null;
-      }
-
-      content += this.setterTemplate(property);
-    }
-
-    this.renderTemplate(content);
-  }
-
-  insertAllGetterAndSetter() {
-    console.log("command created and running");
-    const editor = this.activeEditor();
-    let content = "";
-
-    for (let i = 0; i < editor.document.lineCount; i++) {
-      const line = editor.document.lineAt(i);
-      console.log(line);
-      // end loop asap
-      if (line.text == "") continue;
-
-      let property;
-      try {
-        property = Property.fromLine(editor, line);
-      } catch (error) {
-        continue;
-      }
-      if (!property) continue;
-
-      console.log(`>> property:`);
-      console.log(property);
-
-      content += this.getterTemplate(property) + this.setterTemplate(property);
-    }
-
-    this.renderTemplate(content);
-  }
-
-  getterTemplate(prop: Property) {
-    const name = prop.getName();
-    const description = prop.getDescription();
-    const tab = prop.getIndentation();
-    const type = prop.getType();
-    const spacesAfterReturn = Array(
-      this.config.getInt("spacesAfterReturn", 2) + 1
-    ).join(" ");
-    const templateFile = this.config.get("getterTemplate", "getter.js");
-
-    if (this.templatesManager.exists(templateFile)) {
-      const template = require(this.templatesManager.path(templateFile));
-
-      return template(prop);
-    }
-
-    return (
-      `\n` +
-      tab +
-      `/**\n` +
-      tab +
-      ` * ` +
-      prop.getterDescription() +
-      `\n` +
-      (type ? tab + ` *\n` : ``) +
-      (type ? tab + ` * @return` + spacesAfterReturn + type + `\n` : ``) +
-      tab +
-      ` */\n` +
-      tab +
-      `public function ` +
-      prop.getterName() +
-      `()\n` +
-      tab +
-      `{\n` +
-      tab +
-      tab +
-      `return $this->` +
-      name +
-      `;\n` +
-      tab +
-      `}\n`
-    );
-  }
-
-  setterTemplate(prop: Property) {
-    const name = prop.getName();
-    const description = prop.getDescription();
-    const tab = prop.getIndentation();
-    const type = prop.getType();
-    const typeHint = prop.getTypeHint();
-    const spacesAfterParam = Array(
-      this.config.getInt("spacesAfterParam", 2) + 1
-    ).join(" ");
-    const spacesAfterParamVar = Array(
-      this.config.getInt("spacesAfterParamVar", 2) + 1
-    ).join(" ");
-    const spacesAfterReturn = Array(
-      this.config.getInt("spacesAfterReturn", 2) + 1
-    ).join(" ");
-
-    const templateFile = this.config.get("setterTemplate", "setter.js");
-
-    if (this.templatesManager.exists(templateFile)) {
-      const template = require(this.templatesManager.path(templateFile));
-
-      return template(prop);
-    }
-
-    return (
-      `\n` +
-      tab +
-      `/**\n` +
-      tab +
-      ` * ` +
-      prop.setterDescription() +
-      `\n` +
-      (type ? tab + ` *\n` : ``) +
-      (type
-        ? tab +
-          ` * @param` +
-          spacesAfterParam +
-          type +
-          spacesAfterParamVar +
-          `$` +
-          name +
-          (description ? `  ` + description : ``) +
-          `\n`
-        : ``) +
-      tab +
-      ` *\n` +
-      tab +
-      ` * @return` +
-      spacesAfterReturn +
-      `self\n` +
-      tab +
-      ` */\n` +
-      tab +
-      `public function ` +
-      prop.setterName() +
-      `(` +
-      (typeHint ? typeHint + ` ` : ``) +
-      `$` +
-      name +
-      `)\n` +
-      tab +
-      `{\n` +
-      tab +
-      tab +
-      `$this->` +
-      name +
-      ` = $` +
-      name +
-      `;\n` +
-      `\n` +
-      tab +
-      tab +
-      `return $this;\n` +
-      tab +
-      `}\n`
-    );
-  }
-
-  renderTemplate(template: string) {
-    if (!template) {
-      this.showErrorMessage("Missing template to render.");
-      return;
-    }
-
-    let insertLine = this.insertLine();
-
-    if (!insertLine) {
-      this.showErrorMessage("Unable to detect insert line for template.");
-      return;
-    }
-
-    const editor = this.activeEditor();
-    let resolver = this;
-
-    editor
-      .edit(function (edit: vscode.TextEditorEdit) {
-        edit.replace(new vscode.Position(insertLine.lineNumber, 0), template);
-      })
-      .then(
-        (success) => {
-          if (resolver.isRedirectEnabled() && success) {
-            const redirector = new Redirector(editor);
-            redirector.goToLine(this.closingClassLine().lineNumber - 1);
-          }
-        },
-        (error) => {
-          this.showErrorMessage(`Error generating functions: ` + error);
+        if (editor.document.languageId !== "php") {
+            throw new Error("Not a PHP file.");
         }
-      );
-  }
 
-  insertLine() {
-    return this.closingClassLine();
-  }
+        this.config = new Configuration();
+        this.templatesManager = new TemplatesManager();
+    }
 
-  isRedirectEnabled(): boolean {
-    return true === this.config.get("redirect", true);
-  }
+    activeEditor() {
+        return vscode.window.activeTextEditor;
+    }
 
-  showErrorMessage(message: string) {
-    message =
-      "phpGettersSetters error: " + message.replace(/\$\(.+?\)\s\s/, "");
+    closingClassLine() {
+        const editor = this.activeEditor();
 
-    vscode.window.showErrorMessage(message);
-  }
+        for (
+            let lineNumber = editor.document.lineCount - 1;
+            lineNumber > 0;
+            lineNumber--
+        ) {
+            const line = editor.document.lineAt(lineNumber);
+            const text = line.text.trim();
 
-  showInformationMessage(message: string) {
-    message = "phpGettersSetters info: " + message.replace(/\$\(.+?\)\s\s/, "");
+            if (text.startsWith("}")) {
+                return line;
+            }
+        }
 
-    vscode.window.showInformationMessage(message);
-  }
+        return null;
+    }
+
+    insertGetter() {
+        const editor = this.activeEditor();
+        let property = null;
+        let content = "";
+
+        for (let index = 0; index < editor.selections.length; index++) {
+            const selection = editor.selections[index];
+
+            try {
+                property = Property.fromEditorPosition(
+                    editor,
+                    selection.active
+                );
+            } catch (error) {
+                this.showErrorMessage(error.message);
+                return null;
+            }
+
+            content += this.getterTemplate(property);
+        }
+
+        this.renderTemplate(content);
+    }
+
+    insertGetterAndSetter() {
+        const editor = this.activeEditor();
+        let property = null;
+        let content = "";
+
+        for (let index = 0; index < editor.selections.length; index++) {
+            const selection = editor.selections[index];
+
+            try {
+                property = Property.fromEditorPosition(
+                    editor,
+                    selection.active
+                );
+            } catch (error) {
+                this.showErrorMessage(error.message);
+                return null;
+            }
+
+            content +=
+                this.getterTemplate(property) + this.setterTemplate(property);
+        }
+
+        this.renderTemplate(content);
+    }
+
+    insertSetter() {
+        const editor = this.activeEditor();
+        let property = null;
+        let content = "";
+
+        for (let index = 0; index < editor.selections.length; index++) {
+            const selection = editor.selections[index];
+
+            try {
+                property = Property.fromEditorPosition(
+                    editor,
+                    selection.active
+                );
+            } catch (error) {
+                this.showErrorMessage(error.message);
+                return null;
+            }
+
+            content += this.setterTemplate(property);
+        }
+
+        this.renderTemplate(content);
+    }
+
+    /**
+     * Iterates all lines in the active document searching for properties,
+     * and create getters and setters for every property.
+     * Does NOT recognize different classes in a single document.
+     */
+    insertAllGetterAndSetter() {
+        const editor = this.activeEditor();
+        let content = "";
+
+        for (let i = 0; i < editor.document.lineCount; i++) {
+            const line = editor.document.lineAt(i);
+            // End loop asap
+            if (line.text == "") continue;
+
+            let property;
+            try {
+                property = Property.fromLine(editor, line);
+            } catch (error) {
+                continue;
+            }
+            if (!property) continue;
+
+            content +=
+                this.getterTemplate(property) + this.setterTemplate(property);
+        }
+
+        this.renderTemplate(content);
+    }
+
+    getterTemplate(prop: Property) {
+        const name = prop.getName();
+        const description = prop.getDescription();
+        const tab = prop.getIndentation();
+        const type = prop.getType();
+        const spacesAfterReturn = Array(
+            this.config.getInt("spacesAfterReturn", 2) + 1
+        ).join(" ");
+        const templateFile = this.config.get("getterTemplate", "getter.js");
+
+        if (this.templatesManager.exists(templateFile)) {
+            const template = require(this.templatesManager.path(templateFile));
+
+            return template(prop);
+        }
+
+        return (
+            `\n` +
+            tab +
+            `/**\n` +
+            tab +
+            ` * ` +
+            prop.getterDescription() +
+            `\n` +
+            (type ? tab + ` *\n` : ``) +
+            (type ? tab + ` * @return` + spacesAfterReturn + type + `\n` : ``) +
+            tab +
+            ` */\n` +
+            tab +
+            `public function ` +
+            prop.getterName() +
+            `()\n` +
+            tab +
+            `{\n` +
+            tab +
+            tab +
+            `return $this->` +
+            name +
+            `;\n` +
+            tab +
+            `}\n`
+        );
+    }
+
+    setterTemplate(prop: Property) {
+        const name = prop.getName();
+        const description = prop.getDescription();
+        const tab = prop.getIndentation();
+        const type = prop.getType();
+        const typeHint = prop.getTypeHint();
+        const spacesAfterParam = Array(
+            this.config.getInt("spacesAfterParam", 2) + 1
+        ).join(" ");
+        const spacesAfterParamVar = Array(
+            this.config.getInt("spacesAfterParamVar", 2) + 1
+        ).join(" ");
+        const spacesAfterReturn = Array(
+            this.config.getInt("spacesAfterReturn", 2) + 1
+        ).join(" ");
+
+        const templateFile = this.config.get("setterTemplate", "setter.js");
+
+        if (this.templatesManager.exists(templateFile)) {
+            const template = require(this.templatesManager.path(templateFile));
+
+            return template(prop);
+        }
+
+        return (
+            `\n` +
+            tab +
+            `/**\n` +
+            tab +
+            ` * ` +
+            prop.setterDescription() +
+            `\n` +
+            (type ? tab + ` *\n` : ``) +
+            (type
+                ? tab +
+                  ` * @param` +
+                  spacesAfterParam +
+                  type +
+                  spacesAfterParamVar +
+                  `$` +
+                  name +
+                  (description ? `  ` + description : ``) +
+                  `\n`
+                : ``) +
+            tab +
+            ` *\n` +
+            tab +
+            ` * @return` +
+            spacesAfterReturn +
+            `self\n` +
+            tab +
+            ` */\n` +
+            tab +
+            `public function ` +
+            prop.setterName() +
+            `(` +
+            (typeHint ? typeHint + ` ` : ``) +
+            `$` +
+            name +
+            `)\n` +
+            tab +
+            `{\n` +
+            tab +
+            tab +
+            `$this->` +
+            name +
+            ` = $` +
+            name +
+            `;\n` +
+            `\n` +
+            tab +
+            tab +
+            `return $this;\n` +
+            tab +
+            `}\n`
+        );
+    }
+
+    renderTemplate(template: string) {
+        if (!template) {
+            this.showErrorMessage("Missing template to render.");
+            return;
+        }
+
+        let insertLine = this.insertLine();
+
+        if (!insertLine) {
+            this.showErrorMessage("Unable to detect insert line for template.");
+            return;
+        }
+
+        const editor = this.activeEditor();
+        let resolver = this;
+
+        editor
+            .edit(function (edit: vscode.TextEditorEdit) {
+                edit.replace(
+                    new vscode.Position(insertLine.lineNumber, 0),
+                    template
+                );
+            })
+            .then(
+                (success) => {
+                    if (resolver.isRedirectEnabled() && success) {
+                        const redirector = new Redirector(editor);
+                        redirector.goToLine(
+                            this.closingClassLine().lineNumber - 1
+                        );
+                    }
+                },
+                (error) => {
+                    this.showErrorMessage(
+                        `Error generating functions: ` + error
+                    );
+                }
+            );
+    }
+
+    insertLine() {
+        return this.closingClassLine();
+    }
+
+    isRedirectEnabled(): boolean {
+        return true === this.config.get("redirect", true);
+    }
+
+    showErrorMessage(message: string) {
+        message =
+            "phpGettersSetters error: " + message.replace(/\$\(.+?\)\s\s/, "");
+
+        vscode.window.showErrorMessage(message);
+    }
+
+    showInformationMessage(message: string) {
+        message =
+            "phpGettersSetters info: " + message.replace(/\$\(.+?\)\s\s/, "");
+
+        vscode.window.showInformationMessage(message);
+    }
 }
 
 function activate(context: vscode.ExtensionContext) {
-  let resolver = new Resolver();
+    let resolver = new Resolver();
 
-  let insertGetter = vscode.commands.registerCommand(
-    "phpGettersSetters.insertGetter",
-    () => resolver.insertGetter()
-  );
-  let insertSetter = vscode.commands.registerCommand(
-    "phpGettersSetters.insertSetter",
-    () => resolver.insertSetter()
-  );
-  let insertGetterAndSetter = vscode.commands.registerCommand(
-    "phpGettersSetters.insertGetterAndSetter",
-    () => resolver.insertGetterAndSetter()
-  );
-  let insertAllGetterAndSetter = vscode.commands.registerCommand(
-    "phpGettersSetters.insertAllGetterAndSetter",
-    () => resolver.insertAllGetterAndSetter()
-  );
+    let insertGetter = vscode.commands.registerCommand(
+        "phpGettersSetters.insertGetter",
+        () => resolver.insertGetter()
+    );
+    let insertSetter = vscode.commands.registerCommand(
+        "phpGettersSetters.insertSetter",
+        () => resolver.insertSetter()
+    );
+    let insertGetterAndSetter = vscode.commands.registerCommand(
+        "phpGettersSetters.insertGetterAndSetter",
+        () => resolver.insertGetterAndSetter()
+    );
+    let insertAllGetterAndSetter = vscode.commands.registerCommand(
+        "phpGettersSetters.insertAllGetterAndSetter",
+        () => resolver.insertAllGetterAndSetter()
+    );
 
-  context.subscriptions.push(insertGetter);
-  context.subscriptions.push(insertSetter);
-  context.subscriptions.push(insertGetterAndSetter);
-  context.subscriptions.push(insertAllGetterAndSetter);
+    context.subscriptions.push(insertGetter);
+    context.subscriptions.push(insertSetter);
+    context.subscriptions.push(insertGetterAndSetter);
+    context.subscriptions.push(insertAllGetterAndSetter);
 }
 
 function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -316,6 +316,7 @@ function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(insertGetter);
   context.subscriptions.push(insertSetter);
   context.subscriptions.push(insertGetterAndSetter);
+  context.subscriptions.push(insertAllGetterAndSetter);
 }
 
 function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,19 +115,29 @@ class Resolver {
   insertAllGetterAndSetter() {
     console.log("command created and running");
     const editor = this.activeEditor();
+    let content = "";
 
-    const properties: Property[] = [];
     for (let i = 0; i < editor.document.lineCount; i++) {
       const line = editor.document.lineAt(i);
       console.log(line);
-      if (line.text !== "") {
-        const property = Property.fromLine(editor, line);
-        if (!property) continue;
+      // end loop asap
+      if (line.text == "") continue;
 
-        console.log(`>> property:`);
-        console.log(property);
+      let property;
+      try {
+        property = Property.fromLine(editor, line);
+      } catch (error) {
+        continue;
       }
+      if (!property) continue;
+
+      console.log(`>> property:`);
+      console.log(property);
+
+      content += this.getterTemplate(property) + this.setterTemplate(property);
     }
+
+    this.renderTemplate(content);
   }
 
   getterTemplate(prop: Property) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -114,6 +114,20 @@ class Resolver {
 
   insertAllGetterAndSetter() {
     console.log("command created and running");
+    const editor = this.activeEditor();
+
+    const properties: Property[] = [];
+    for (let i = 0; i < editor.document.lineCount; i++) {
+      const line = editor.document.lineAt(i);
+      console.log(line);
+      if (line.text !== "") {
+        const property = Property.fromLine(editor, line);
+        if (!property) continue;
+
+        console.log(`>> property:`);
+        console.log(property);
+      }
+    }
   }
 
   getterTemplate(prop: Property) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,248 +1,324 @@
-'use strict';
+"use strict";
 
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 import Redirector from "./Redirector";
 import Property from "./Property";
 import Configuration from "./Configuration";
-import TemplatesManager from './TemplatesManager';
+import TemplatesManager from "./TemplatesManager";
 
 class Resolver {
-    config: Configuration;
-    templatesManager: TemplatesManager;
+  config: Configuration;
+  templatesManager: TemplatesManager;
 
-    /**
-     * Types that won't be recognised as valid type hints
-     */
-    pseudoTypes = ['mixed', 'number', 'callback', 'object', 'void'];
+  /**
+   * Types that won't be recognised as valid type hints
+   */
+  pseudoTypes = ["mixed", "number", "callback", "object", "void"];
 
-    public constructor()
-    {
-        const editor = this.activeEditor();
+  public constructor() {
+    const editor = this.activeEditor();
 
-        if (editor.document.languageId !== 'php') {
-            throw new Error('Not a PHP file.');
-        }
-
-        this.config = new Configuration;
-        this.templatesManager = new TemplatesManager;
+    if (editor.document.languageId !== "php") {
+      throw new Error("Not a PHP file.");
     }
 
+    this.config = new Configuration();
+    this.templatesManager = new TemplatesManager();
+  }
 
-    activeEditor() {
-        return vscode.window.activeTextEditor;
+  activeEditor() {
+    return vscode.window.activeTextEditor;
+  }
+
+  closingClassLine() {
+    const editor = this.activeEditor();
+
+    for (
+      let lineNumber = editor.document.lineCount - 1;
+      lineNumber > 0;
+      lineNumber--
+    ) {
+      const line = editor.document.lineAt(lineNumber);
+      const text = line.text.trim();
+
+      if (text.startsWith("}")) {
+        return line;
+      }
     }
 
-    closingClassLine() {
-        const editor = this.activeEditor();
+    return null;
+  }
 
-        for (let lineNumber = editor.document.lineCount - 1; lineNumber > 0; lineNumber--) {
-            const line = editor.document.lineAt(lineNumber);
-            const text = line.text.trim();
+  insertGetter() {
+    const editor = this.activeEditor();
+    let property = null;
+    let content = "";
 
-            if (text.startsWith('}')) {
-                return line;
-            }
-        }
+    for (let index = 0; index < editor.selections.length; index++) {
+      const selection = editor.selections[index];
 
+      try {
+        property = Property.fromEditorPosition(editor, selection.active);
+      } catch (error) {
+        this.showErrorMessage(error.message);
         return null;
+      }
+
+      content += this.getterTemplate(property);
     }
 
-    insertGetter() {
-        const editor = this.activeEditor();
-        let property = null;
-        let content = '';
+    this.renderTemplate(content);
+  }
 
-        for (let index = 0; index < editor.selections.length; index++) {
-            const selection = editor.selections[index];
+  insertGetterAndSetter() {
+    const editor = this.activeEditor();
+    let property = null;
+    let content = "";
 
-            try {
-                property = Property.fromEditorPosition(editor, selection.active);
-            } catch (error) {
-                this.showErrorMessage(error.message);
-                return null;
-            }
+    for (let index = 0; index < editor.selections.length; index++) {
+      const selection = editor.selections[index];
 
-            content += this.getterTemplate(property);
+      try {
+        property = Property.fromEditorPosition(editor, selection.active);
+      } catch (error) {
+        this.showErrorMessage(error.message);
+        return null;
+      }
+
+      content += this.getterTemplate(property) + this.setterTemplate(property);
+    }
+
+    this.renderTemplate(content);
+  }
+
+  insertSetter() {
+    const editor = this.activeEditor();
+    let property = null;
+    let content = "";
+
+    for (let index = 0; index < editor.selections.length; index++) {
+      const selection = editor.selections[index];
+
+      try {
+        property = Property.fromEditorPosition(editor, selection.active);
+      } catch (error) {
+        this.showErrorMessage(error.message);
+        return null;
+      }
+
+      content += this.setterTemplate(property);
+    }
+
+    this.renderTemplate(content);
+  }
+
+  insertAllGetterAndSetter() {
+    console.log("command created and running");
+  }
+
+  getterTemplate(prop: Property) {
+    const name = prop.getName();
+    const description = prop.getDescription();
+    const tab = prop.getIndentation();
+    const type = prop.getType();
+    const spacesAfterReturn = Array(
+      this.config.getInt("spacesAfterReturn", 2) + 1
+    ).join(" ");
+    const templateFile = this.config.get("getterTemplate", "getter.js");
+
+    if (this.templatesManager.exists(templateFile)) {
+      const template = require(this.templatesManager.path(templateFile));
+
+      return template(prop);
+    }
+
+    return (
+      `\n` +
+      tab +
+      `/**\n` +
+      tab +
+      ` * ` +
+      prop.getterDescription() +
+      `\n` +
+      (type ? tab + ` *\n` : ``) +
+      (type ? tab + ` * @return` + spacesAfterReturn + type + `\n` : ``) +
+      tab +
+      ` */\n` +
+      tab +
+      `public function ` +
+      prop.getterName() +
+      `()\n` +
+      tab +
+      `{\n` +
+      tab +
+      tab +
+      `return $this->` +
+      name +
+      `;\n` +
+      tab +
+      `}\n`
+    );
+  }
+
+  setterTemplate(prop: Property) {
+    const name = prop.getName();
+    const description = prop.getDescription();
+    const tab = prop.getIndentation();
+    const type = prop.getType();
+    const typeHint = prop.getTypeHint();
+    const spacesAfterParam = Array(
+      this.config.getInt("spacesAfterParam", 2) + 1
+    ).join(" ");
+    const spacesAfterParamVar = Array(
+      this.config.getInt("spacesAfterParamVar", 2) + 1
+    ).join(" ");
+    const spacesAfterReturn = Array(
+      this.config.getInt("spacesAfterReturn", 2) + 1
+    ).join(" ");
+
+    const templateFile = this.config.get("setterTemplate", "setter.js");
+
+    if (this.templatesManager.exists(templateFile)) {
+      const template = require(this.templatesManager.path(templateFile));
+
+      return template(prop);
+    }
+
+    return (
+      `\n` +
+      tab +
+      `/**\n` +
+      tab +
+      ` * ` +
+      prop.setterDescription() +
+      `\n` +
+      (type ? tab + ` *\n` : ``) +
+      (type
+        ? tab +
+          ` * @param` +
+          spacesAfterParam +
+          type +
+          spacesAfterParamVar +
+          `$` +
+          name +
+          (description ? `  ` + description : ``) +
+          `\n`
+        : ``) +
+      tab +
+      ` *\n` +
+      tab +
+      ` * @return` +
+      spacesAfterReturn +
+      `self\n` +
+      tab +
+      ` */\n` +
+      tab +
+      `public function ` +
+      prop.setterName() +
+      `(` +
+      (typeHint ? typeHint + ` ` : ``) +
+      `$` +
+      name +
+      `)\n` +
+      tab +
+      `{\n` +
+      tab +
+      tab +
+      `$this->` +
+      name +
+      ` = $` +
+      name +
+      `;\n` +
+      `\n` +
+      tab +
+      tab +
+      `return $this;\n` +
+      tab +
+      `}\n`
+    );
+  }
+
+  renderTemplate(template: string) {
+    if (!template) {
+      this.showErrorMessage("Missing template to render.");
+      return;
+    }
+
+    let insertLine = this.insertLine();
+
+    if (!insertLine) {
+      this.showErrorMessage("Unable to detect insert line for template.");
+      return;
+    }
+
+    const editor = this.activeEditor();
+    let resolver = this;
+
+    editor
+      .edit(function (edit: vscode.TextEditorEdit) {
+        edit.replace(new vscode.Position(insertLine.lineNumber, 0), template);
+      })
+      .then(
+        (success) => {
+          if (resolver.isRedirectEnabled() && success) {
+            const redirector = new Redirector(editor);
+            redirector.goToLine(this.closingClassLine().lineNumber - 1);
+          }
+        },
+        (error) => {
+          this.showErrorMessage(`Error generating functions: ` + error);
         }
+      );
+  }
 
-        this.renderTemplate(content);
-    }
+  insertLine() {
+    return this.closingClassLine();
+  }
 
-    insertGetterAndSetter(){
-        const editor = this.activeEditor();
-        let property = null;
-        let content = '';
+  isRedirectEnabled(): boolean {
+    return true === this.config.get("redirect", true);
+  }
 
-        for (let index = 0; index < editor.selections.length; index++) {
-            const selection = editor.selections[index];
+  showErrorMessage(message: string) {
+    message =
+      "phpGettersSetters error: " + message.replace(/\$\(.+?\)\s\s/, "");
 
-            try {
-                property = Property.fromEditorPosition(editor, selection.active);
-            } catch (error) {
-                this.showErrorMessage(error.message);
-                return null;
-            }
+    vscode.window.showErrorMessage(message);
+  }
 
-            content += this.getterTemplate(property) + this.setterTemplate(property);
-        }
+  showInformationMessage(message: string) {
+    message = "phpGettersSetters info: " + message.replace(/\$\(.+?\)\s\s/, "");
 
-        this.renderTemplate(content);
-    }
-
-    insertSetter() {
-        const editor = this.activeEditor();
-        let property = null;
-        let content = '';
-
-        for (let index = 0; index < editor.selections.length; index++) {
-            const selection = editor.selections[index];
-
-            try {
-                property = Property.fromEditorPosition(editor, selection.active);
-            } catch (error) {
-                this.showErrorMessage(error.message);
-                return null;
-            }
-
-            content += this.setterTemplate(property);
-        }
-
-        this.renderTemplate(content);
-    }
-
-    getterTemplate(prop: Property) {
-        const name = prop.getName();
-        const description = prop.getDescription();
-        const tab = prop.getIndentation();
-        const type = prop.getType();
-        const spacesAfterReturn = Array(this.config.getInt('spacesAfterReturn', 2) + 1).join(' ');
-        const templateFile = this.config.get('getterTemplate', 'getter.js');
-
-        if (this.templatesManager.exists(templateFile)) {
-            const template = require(this.templatesManager.path(templateFile));
-
-            return template(prop);
-        }
-
-        return  (
-            `\n`
-            + tab + `/**\n`
-            + tab + ` * ` + prop.getterDescription() + `\n`
-            + (type ? tab + ` *\n` : ``)
-            + (type ? tab + ` * @return` + spacesAfterReturn + type + `\n` : ``)
-            + tab + ` */\n`
-            + tab + `public function ` + prop.getterName() + `()\n`
-            + tab + `{\n`
-            + tab + tab + `return $this->` + name + `;\n`
-            + tab + `}\n`
-        );
-    }
-
-    setterTemplate(prop: Property) {
-        const name = prop.getName();
-        const description = prop.getDescription();
-        const tab = prop.getIndentation();
-        const type = prop.getType();
-        const typeHint = prop.getTypeHint();
-        const spacesAfterParam = Array(this.config.getInt('spacesAfterParam', 2) + 1).join(' ');
-        const spacesAfterParamVar = Array(this.config.getInt('spacesAfterParamVar', 2) + 1).join(' ');
-        const spacesAfterReturn = Array(this.config.getInt('spacesAfterReturn', 2) + 1).join(' ');
-
-        const templateFile = this.config.get('setterTemplate', 'setter.js');
-
-        if (this.templatesManager.exists(templateFile)) {
-            const template = require(this.templatesManager.path(templateFile));
-
-            return template(prop);
-        }
-
-        return (
-            `\n`
-            + tab + `/**\n`
-            + tab + ` * ` + prop.setterDescription() + `\n`
-            + (type ? tab + ` *\n` : ``)
-            + (type ? tab + ` * @param` + spacesAfterParam + type + spacesAfterParamVar + `$` + name + (description ? `  ` + description : ``) + `\n` : ``)
-            + tab + ` *\n`
-            + tab + ` * @return` + spacesAfterReturn + `self\n`
-            + tab + ` */\n`
-            + tab + `public function ` + prop.setterName() + `(` + (typeHint ? typeHint + ` ` : ``) + `$` + name + `)\n`
-            + tab+ `{\n`
-            + tab + tab + `$this->` + name + ` = $` + name + `;\n`
-            + `\n`
-            + tab + tab + `return $this;\n`
-            + tab + `}\n`
-        );
-    }
-
-    renderTemplate(template: string) {
-        if (!template) {
-            this.showErrorMessage('Missing template to render.');
-            return;
-        }
-
-        let insertLine = this.insertLine();
-
-        if (!insertLine) {
-            this.showErrorMessage('Unable to detect insert line for template.');
-            return;
-        }
-
-        const editor = this.activeEditor();
-        let resolver = this;
-
-        editor.edit(function(edit: vscode.TextEditorEdit){
-            edit.replace(
-                new vscode.Position(insertLine.lineNumber, 0),
-                template
-            );
-        }).then(
-            success => {
-                if (resolver.isRedirectEnabled() && success) {
-                    const redirector = new Redirector(editor);
-                    redirector.goToLine(this.closingClassLine().lineNumber - 1);
-                }
-            },
-            error => {
-                this.showErrorMessage(`Error generating functions: ` + error);
-            }
-        );
-    }
-
-    insertLine() {
-        return this.closingClassLine();
-    }
-
-    isRedirectEnabled() : boolean {
-        return true === this.config.get('redirect', true);
-    }
-
-    showErrorMessage(message: string) {
-        message = 'phpGettersSetters error: ' + message.replace(/\$\(.+?\)\s\s/, '');
-
-        vscode.window.showErrorMessage(message);
-    }
-
-    showInformationMessage(message: string) {
-        message = 'phpGettersSetters info: ' + message.replace(/\$\(.+?\)\s\s/, '');
-
-        vscode.window.showInformationMessage(message);
-    }
+    vscode.window.showInformationMessage(message);
+  }
 }
 
 function activate(context: vscode.ExtensionContext) {
-    let resolver = new Resolver;
+  let resolver = new Resolver();
 
-    let insertGetter = vscode.commands.registerCommand('phpGettersSetters.insertGetter', () => resolver.insertGetter());
-    let insertSetter = vscode.commands.registerCommand('phpGettersSetters.insertSetter', () => resolver.insertSetter());
-    let insertGetterAndSetter = vscode.commands.registerCommand('phpGettersSetters.insertGetterAndSetter', () => resolver.insertGetterAndSetter());
+  let insertGetter = vscode.commands.registerCommand(
+    "phpGettersSetters.insertGetter",
+    () => resolver.insertGetter()
+  );
+  let insertSetter = vscode.commands.registerCommand(
+    "phpGettersSetters.insertSetter",
+    () => resolver.insertSetter()
+  );
+  let insertGetterAndSetter = vscode.commands.registerCommand(
+    "phpGettersSetters.insertGetterAndSetter",
+    () => resolver.insertGetterAndSetter()
+  );
+  let insertAllGetterAndSetter = vscode.commands.registerCommand(
+    "phpGettersSetters.insertAllGetterAndSetter",
+    () => resolver.insertAllGetterAndSetter()
+  );
 
-    context.subscriptions.push(insertGetter);
-    context.subscriptions.push(insertSetter);
-    context.subscriptions.push(insertGetterAndSetter);
+  context.subscriptions.push(insertGetter);
+  context.subscriptions.push(insertSetter);
+  context.subscriptions.push(insertGetterAndSetter);
 }
 
-function deactivate() {
-}
+function deactivate() {}
 
 exports.activate = activate;
 exports.deactivate = deactivate;


### PR DESCRIPTION
I specifically needed a way to add all the getters and setters for all properties at once, instead of selecting them one by one.

I just add a command to the right button menu that search for all properties in the active document, as they are defined in the original code, and again apply the original code(with templates and all the original features) to create getters and setters of all the found properties.

Also, I packaged it in a VSIX like half a month ago and have being using it since then without a problem.