### PR TITLE
Fix regex to handle default values

### DIFF
--- a/src/Property.ts
+++ b/src/Property.ts
@@ -24,7 +24,7 @@ export default class Property {
     static isAProperty(line: vscode.TextLine) {
         const text = line.text;
 
-        return  /(private|public|protected) (\S*)?\s?\$(.*)(;|,){1}\s?(\/\/\s?(.*))?/.test(text);
+        return /(private|public|protected)\s+((\S*)\s+)?\$([a-zA-Z0-9_]+)/.test(text);
     }
 
     /**
@@ -52,7 +52,7 @@ export default class Property {
 
         const activeLineNumber = activePosition.line;
         const activeLine = editor.document.lineAt(activeLineNumber);
-        const activeLineTokens = activeLine.text.match(/(private|public|protected) (\S*)?\s?\$(.*)(;|,){1}\s?(\/\/\s?(.*))?/);
+        const activeLineTokens = activeLine.text.match(/(private|public|protected)\s+((\S*)\s+)?\$([a-zA-Z0-9_]+)/);
 
         if (null === activeLineTokens) {
             throw new Error('Invalid property line');
@@ -60,7 +60,7 @@ export default class Property {
 
         const typehint = activeLineTokens[1];
 
-        const property = new Property(activeLineTokens[3]);
+        const property = new Property(activeLineTokens[4]);
 
         if (typehint !== 'public' && typehint !== 'private' && typehint !== 'protected') {
             property.setType(typehint);
@@ -68,8 +68,8 @@ export default class Property {
 
         property.indentation = activeLine.text.substring(0, activeLine.firstNonWhitespaceCharacterIndex);
 
-        if (activeLineTokens[2]) {
-            property.setType(activeLineTokens[2]);
+        if (activeLineTokens[3]) {
+            property.setType(activeLineTokens[3]);
 
             return property;
         }

--- a/src/Property.ts
+++ b/src/Property.ts
@@ -18,13 +18,23 @@ export default class Property {
 
     /**
      * Check if a property is defined in the provided line
-     * @param line Line of the editor.document to search for a property
-     * @returns Boolean. True if the line defines a property, false otherwise
+     * @param {vscode.TextLine} line Line of the editor.document to search for a property
+     * @returns {RegExpMatchArray | null} RegExpMatchArray if the line defines a property, null otherwise
      */
-    static isAProperty(line: vscode.TextLine) {
+    static isAProperty(line: vscode.TextLine): RegExpMatchArray | null {
         const text = line.text;
 
-        return /(private|public|protected)\s+((\S*)\s+)?\$([a-zA-Z0-9_]+)/.test(text);
+        const matches = text.match(/(private|public|protected)\s+((\S*)\s+)?\$([a-zA-Z0-9_]+)/);
+
+        if (null === matches) {
+            return null;
+        }
+
+        if ('static' === matches[3]) {
+            return null;
+        }
+
+        return matches;
     }
 
     /**
@@ -52,7 +62,7 @@ export default class Property {
 
         const activeLineNumber = activePosition.line;
         const activeLine = editor.document.lineAt(activeLineNumber);
-        const activeLineTokens = activeLine.text.match(/(private|public|protected)\s+((\S*)\s+)?\$([a-zA-Z0-9_]+)/);
+        const activeLineTokens = Property.isAProperty(activeLine);
 
         if (null === activeLineTokens) {
             throw new Error('Invalid property line');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -142,6 +142,8 @@ class Resolver {
             throw new Error('Error editor not available');
         }
 
+        let hasProperties = false;
+
         for (let i = 0; i < editor.document.lineCount; i++) {
             const line = editor.document.lineAt(i);
             // End loop asap
@@ -157,6 +159,13 @@ class Resolver {
 
             content +=
                 this.getterTemplate(property) + this.setterTemplate(property);
+
+            hasProperties = true;
+        }
+
+        if (!hasProperties) {
+            this.showErrorMessage('No properties found in this file.');
+            return;
         }
 
         this.renderTemplate(content);

--- a/src/test/suite/Property.test.ts
+++ b/src/test/suite/Property.test.ts
@@ -23,10 +23,10 @@ class TextLine implements vscode.TextLine {
 suite("Property", () => {
     test("isAProperty well detect properties", () => {
         const shouldPass = (textLine: string): void => {
-            assert.equal(
+            assert.notStrictEqual(
                 Property.isAProperty(new TextLine(textLine)),
-                true,
-                `Expected "${textLine}" to be a propery`
+                null,
+                `Expected "${textLine}" to be a property`
             );
         };
 
@@ -54,12 +54,15 @@ suite("Property", () => {
         const shallNotPass = (textLine: string): void => {
             assert.strictEqual(
                 Property.isAProperty(new TextLine(textLine)),
-                false,
-                `Expected "${textLine}" to NOT be a propery`
+                null,
+                `Expected "${textLine}" NOT to be a property`
             );
         };
 
         shallNotPass('class Hello');
         shallNotPass('private function hello()');
+        shallNotPass('public const FOO = \'BAR\'');
+        shallNotPass('public static $foo = \'bar\'');
+        shallNotPass('public static string $foo = \'bar\'');
     });
 });

--- a/src/test/suite/Property.test.ts
+++ b/src/test/suite/Property.test.ts
@@ -1,0 +1,65 @@
+import * as assert from 'assert';
+
+// You can import and use all API from the 'vscode' module
+// as well as import your extension to test it
+import * as vscode from 'vscode';
+import Property from '../../Property';
+
+const fakeRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
+
+class TextLine implements vscode.TextLine {
+    lineNumber: number = 0;
+    range: vscode.Range = fakeRange;
+    rangeIncludingLineBreak: vscode.Range = fakeRange;
+    firstNonWhitespaceCharacterIndex: number = 0;
+    isEmptyOrWhitespace: boolean = false;
+
+    public constructor(
+        readonly text: string
+    ) {}
+}
+
+// Defines a Mocha test suite to group tests of similar kind together
+suite("Property", () => {
+    test("isAProperty well detect properties", () => {
+        const shouldPass = (textLine: string): void => {
+            assert.equal(
+                Property.isAProperty(new TextLine(textLine)),
+                true,
+                `Expected "${textLine}" to be a propery`
+            );
+        };
+
+        shouldPass('private $foo;');
+        shouldPass('    private $foo;');
+        shouldPass('private $foo = "ok";');
+        shouldPass('private string $foo;');
+        shouldPass('private string $foo7;');
+        shouldPass('private string $foo = "ok";');
+        shouldPass('private string $foo8 = "ok";');
+        shouldPass('private DateTime $foo;');
+        shouldPass('private \\DateTime $foo;');
+        shouldPass('private ?string $foo;');
+        shouldPass('private ?string $foo = null;');
+        shouldPass('private Sub\\Namespace $foo;');
+        shouldPass('private \\Sub\\Namespace $foo;');
+        shouldPass('protected \\Sub\\Namespace $foo;');
+        shouldPass('public \\Sub\\Namespace $foo;');
+        shouldPass('public ?\\DateTime $foo;');
+        shouldPass('public T $foo;');
+        shouldPass('public \\T $foo;');
+        shouldPass('public ?\\T $foo = new T();');
+        shouldPass('public string $foo; // comment');
+
+        const shallNotPass = (textLine: string): void => {
+            assert.strictEqual(
+                Property.isAProperty(new TextLine(textLine)),
+                false,
+                `Expected "${textLine}" to NOT be a propery`
+            );
+        };
+
+        shallNotPass('class Hello');
+        shallNotPass('private function hello()');
+    });
+});


### PR DESCRIPTION
- Fix: default values, like `private string $foo5 = "ok";`, generating invalid getter/setter:
- Fix: static properties, like `public static $foo = 'bar';`, generating invalid getter/setter:
- For better understanding, error `Missing template` has been replaced by `No properties found in the file` when no properties found in the file