### PR TITLE
This fixes a wrong colon inserted in getter function just after (), which breaks php code.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -321,7 +321,7 @@ class Resolver {
             return `: ` + (nullable ? `?` : ``) + type;
         }
 
-         return '';
+        return '';
     }
 
     getPHPDocType(type: string, nullable = false): string {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -306,7 +306,7 @@ class Resolver {
 
     getSetterTypeHint(type: string, nullable = false): string {
         if (this.isPHP7TypeHintsEnabled()) {
-            return (nullable ? `?` : ``) + type + ` `;
+            return (nullable ? `?` : ``) + type;
         }
 
         return '';
@@ -314,14 +314,14 @@ class Resolver {
 
     getReturnTypeHint(type: null|string, nullable = false): string {
         if (null === type) {
-            type = '';
+            return '';
         }
 
         if (this.isPHP7TypeHintsEnabled()) {
             return `: ` + (nullable ? `?` : ``) + type;
         }
 
-        return '';
+         return '';
     }
 
     getPHPDocType(type: string, nullable = false): string {


### PR DESCRIPTION
If a class have a property with no type declared, and you select the "Insert PHP Getter" command, the getter method created will have a colon ':' after (). This breaks the php code.

This pull request fixes that wrong colon insertion mentioned in #26.
It also excludes a duplicated space in setter function.